### PR TITLE
Wire in link generation to composer

### DIFF
--- a/notification-boot/src/main/java/org/dataconservancy/pass/notification/app/config/SpringBootNotificationConfig.java
+++ b/notification-boot/src/main/java/org/dataconservancy/pass/notification/app/config/SpringBootNotificationConfig.java
@@ -33,6 +33,8 @@ import org.dataconservancy.pass.notification.dispatch.impl.email.TemplateResolve
 import org.dataconservancy.pass.notification.impl.Composer;
 import org.dataconservancy.pass.notification.impl.RecipientAnalyzer;
 import org.dataconservancy.pass.notification.impl.SimpleWhitelist;
+import org.dataconservancy.pass.notification.impl.SubmissionLinkAnalyzer;
+import org.dataconservancy.pass.notification.impl.UserTokenGenerator;
 import org.dataconservancy.pass.notification.model.config.Mode;
 import org.dataconservancy.pass.notification.model.config.NotificationConfig;
 import org.dataconservancy.pass.notification.model.config.RecipientConfig;
@@ -225,10 +227,20 @@ public class SpringBootNotificationConfig {
     public RecipientAnalyzer recipientAnalyzer(Function<Collection<String>, Collection<String>> simpleWhitelist) {
         return new RecipientAnalyzer(simpleWhitelist);
     }
+   
+    @Bean
+    public UserTokenGenerator userTokenGenerator(NotificationConfig config) {
+        return new UserTokenGenerator(config);
+    }
+    
+    @Bean
+    public SubmissionLinkAnalyzer submissionLinkAnalyzer(UserTokenGenerator generator) {
+        return new SubmissionLinkAnalyzer(generator);
+    }
 
     @Bean
-    public Composer composer(NotificationConfig notificationConfig, RecipientAnalyzer recipientAnalyzer, ObjectMapper objectMapper) {
-        return new Composer(notificationConfig, recipientAnalyzer, objectMapper);
+    public Composer composer(NotificationConfig notificationConfig, RecipientAnalyzer recipientAnalyzer, SubmissionLinkAnalyzer sla, ObjectMapper objectMapper) {
+        return new Composer(notificationConfig, recipientAnalyzer, sla, objectMapper);
     }
 
 }

--- a/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/Links.java
+++ b/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/Links.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.notification.impl;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collector.Characteristics.UNORDERED;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+
+import org.dataconservancy.pass.notification.model.Link;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Utility class for working with streams of {@link Link}
+ *
+ * @author apb@jhu.edu
+ */
+public class Links {
+
+    private static Logger LOG = LoggerFactory.getLogger(Links.class);
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    static final Collector<Link, Collection<Link>, String> LINK_COLLECTOR =
+            new Collector<Link, Collection<Link>, String>() {
+
+                @Override
+                public BiConsumer<Collection<Link>, Link> accumulator() {
+                    return (links, link) -> links.add(link);
+                }
+
+                @Override
+                public Set<Characteristics> characteristics() {
+                    return new HashSet<>(asList(UNORDERED));
+                }
+
+                @Override
+                public BinaryOperator<Collection<Link>> combiner() {
+                    return (c1, c2) -> {
+                        c1.addAll(c2);
+                        return c1;
+                    };
+                }
+
+                @Override
+                public Function<Collection<Link>, String> finisher() {
+                    return links -> {
+                        try {
+                            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(links);
+                        } catch (final JsonProcessingException e) {
+                            throw new RuntimeException("Could not serialize links! ", e);
+                        }
+                    };
+                }
+
+                @Override
+                public Supplier<Collection<Link>> supplier() {
+                    return () -> new HashSet<>();
+                }
+
+            };
+
+    /**
+     * Convenience method to concatenate several link streams into one.
+     *
+     * @param streams zero or more streams of links
+     * @return Single stream of links.
+     */
+    @SafeVarargs
+    public static Stream<Link> concat(Stream<Link>... streams) {
+        return Stream.of(streams)
+                .filter(s -> s != null)
+                .flatMap(s -> s);
+    }
+
+    /**
+     * Create a stream containing a single link that is required to exist.
+     * <p>
+     * Verifies that the provided URI is not null.
+     * </p>
+     *
+     * @param href URI being linked to.
+     * @param rel The link relation.
+     * @return Stream containing the required link.
+     */
+    public static Stream<Link> required(URI href, String rel) {
+        requireNonNull(rel, format("Link relation for <%s> must not be null", href));
+        requireNonNull(href, format("Required link %s is null", rel));
+
+        return Stream.of(new Link(href, rel));
+    }
+
+    /**
+     * Create a stream containing zero or one links.
+     * <p>
+     * If the provided URI is not null, then the stream will contain one link.
+     * </p>
+     *
+     * @param href URI being linked to.
+     * @param rel The link relation.
+     * @return Stream containing zero or one links.
+     */
+    public static Stream<Link> optional(URI href, String rel) {
+        if (href != null) {
+            return required(href, rel);
+        } else {
+            LOG.debug("Optional link {} is null, ignoring", rel);
+            return Stream.empty();
+        }
+    }
+
+    /**
+     * Collect a stream of links into a single JSON array.
+     *
+     * @return The stream collector.
+     */
+    public static Collector<Link, Collection<Link>, String> serialized() {
+        return LINK_COLLECTOR;
+    }
+
+    /**
+     * Deserialize a JSON array of links.
+     *
+     * @param json Serialized JSON
+     * @return collection of links.
+     */
+    @SuppressWarnings("unchecked")
+    public static Collection<Link> deserialize(String json) {
+        try {
+            return asList(mapper.readValue(json, Link[].class));
+        } catch (final Exception e) {
+            throw new RuntimeException(format("Could not deserialize json: '%s'", json), e);
+        }
+    }
+
+}

--- a/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/Links.java
+++ b/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/Links.java
@@ -114,8 +114,23 @@ public class Links {
      * @return Stream containing the required link.
      */
     public static Stream<Link> required(URI href, String rel) {
-        requireNonNull(rel, format("Link relation for <%s> must not be null", href));
-        requireNonNull(href, format("Required link %s is null", rel));
+        return required("", href, rel);
+    }
+
+    /**
+     * Create a stream containing a single link that is required to exist.
+     * <p>
+     * Verifies that the provided URI is not null.
+     * </p>
+     *
+     * @param message Error message to be included if an exception is thrown.
+     * @param href URI being linked to.
+     * @param rel The link relation.
+     * @return Stream containing the required link.
+     */
+    public static Stream<Link> required(String message, URI href, String rel) {
+        requireNonNull(rel, format("%s Link relation for <%s> must not be null", message, href));
+        requireNonNull(href, format("%s Required link %s is null", message, rel));
 
         return Stream.of(new Link(href, rel));
     }

--- a/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/SubmissionLinkAnalyzer.java
+++ b/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/SubmissionLinkAnalyzer.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.notification.impl;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Stream.empty;
+import static org.dataconservancy.pass.notification.impl.Links.optional;
+import static org.dataconservancy.pass.notification.impl.Links.required;
+import static org.dataconservancy.pass.notification.model.Link.Rels.SUBMISSION_REVIEW;
+import static org.dataconservancy.pass.notification.model.Link.Rels.SUBMISSION_REVIEW_INVITE;
+import static org.dataconservancy.pass.notification.model.Link.Rels.SUBMISSION_VIEW;
+
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import org.dataconservancy.pass.model.Submission;
+import org.dataconservancy.pass.model.SubmissionEvent;
+import org.dataconservancy.pass.notification.model.Link;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Analyzes a submission+event pair and emits a stream of submission-related {@link Link}s
+ *
+ * @author apb@jhu.edu
+ */
+public class SubmissionLinkAnalyzer implements BiFunction<Submission, SubmissionEvent, Stream<Link>> {
+
+    static final Logger LOG = LoggerFactory.getLogger(SubmissionLinkAnalyzer.class);
+
+    final UserTokenGenerator tokenGenerator;
+
+    /**
+     * Constructor.
+     *
+     * @param generator User token generator, for building invite links.
+     */
+    public SubmissionLinkAnalyzer(final UserTokenGenerator generator) {
+        tokenGenerator = generator;
+    }
+
+    /**
+     * Return all submission-related links associated with a submission+event pair.
+     *
+     * @param submission The submission.
+     * @param event The associated submission event.
+     * @return a stream of links, likely containing zero or one links.
+     */
+    @Override
+    public Stream<Link> apply(Submission submission, SubmissionEvent event) {
+        requireNonNull(submission);
+        requireNonNull(event);
+
+        if (event.getEventType() == null) {
+            LOG.warn("Submission event type was null for {}.  Ignoring.", event.getId());
+            return empty();
+        }
+
+        switch (event.getEventType()) {
+
+        case APPROVAL_REQUESTED_NEWUSER:
+            return required(format("Invalid submissionEvent %s", event.getId()),
+                    event.getLink(),
+                    SUBMISSION_REVIEW_INVITE)
+                            .map(tokenGenerator.forSubmission(submission));
+
+        case APPROVAL_REQUESTED:
+            return required(format("Invalid submissionEvent %s", event.getId()), event.getLink(), SUBMISSION_REVIEW);
+
+        case CHANGES_REQUESTED:
+            return required(format("Invalid submissionEvent %s", event.getId()), event.getLink(), SUBMISSION_REVIEW);
+
+        case SUBMITTED:
+            return optional(event.getLink(), SUBMISSION_VIEW);
+
+        case CANCELLED:
+            return optional(event.getLink(), SUBMISSION_VIEW);
+
+        default:
+
+            // If there is a link, but an unknown submission type, then just blindly pass
+            // along the link.
+            LOG.warn("Encountered unknown submission event type {}", event.getEventType());
+            return optional(event.getLink(), SUBMISSION_VIEW);
+        }
+    }
+}

--- a/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/LinksTest.java
+++ b/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/LinksTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.notification.impl;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.empty;
+import static org.dataconservancy.pass.notification.impl.Links.concat;
+import static org.dataconservancy.pass.notification.impl.Links.deserialize;
+import static org.dataconservancy.pass.notification.impl.Links.optional;
+import static org.dataconservancy.pass.notification.impl.Links.required;
+import static org.dataconservancy.pass.notification.impl.Links.serialized;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import org.dataconservancy.pass.notification.model.Link;
+
+import org.junit.Test;
+
+/**
+ * @author apb@jhu.edu
+ */
+public class LinksTest {
+
+    @Test
+    public void serializationRoundTripTest() {
+        final Collection<Link> links = asList(
+                new Link(randomUri(), "rel1"),
+                new Link(randomUri(), "rel2"));
+
+        final Collection<Link> roundTrippedLinks = deserialize(links.stream().collect(serialized()));
+
+        assertEquals(links.size(), roundTrippedLinks.size());
+        assertTrue(roundTrippedLinks.containsAll(links));
+
+    }
+
+    // Make sure nothing bad happens with the edge case of serializing zero links
+    @Test
+    public void concatZeroMembersSerializationTest() {
+        assertTrue(deserialize(concat().collect(serialized())).isEmpty());
+    }
+
+    // If an "optional" link is present, it should form a stream of exactly one member.
+    @Test
+    public void optionalLinkPresentTest() {
+
+        final URI uri = randomUri();
+        final String rel = "rel1";
+
+        final List<Link> links = optional(uri, rel).collect(toList());
+        assertEquals(1, links.size());
+        assertEquals(uri, links.get(0).getHref());
+        assertEquals(rel, links.get(0).getRel());
+    }
+
+    @Test
+    public void optionalLinkNotPresentTest() {
+        assertTrue(optional(null, "rel").collect(toList()).isEmpty());
+    }
+
+    @Test
+    public void optionalLinkNotPresentNulRelTest() {
+        assertTrue(optional(null, null).collect(toList()).isEmpty());
+    }
+
+    @Test
+    public void requiredLinkPresentTest() {
+        final URI uri = randomUri();
+        final String rel = "rel1";
+
+        final List<Link> links = required(uri, rel).collect(toList());
+        assertEquals(1, links.size());
+        assertEquals(uri, links.get(0).getHref());
+        assertEquals(rel, links.get(0).getRel());
+    }
+
+    @Test
+    public void requiredLinkNotPresentTest() {
+
+        final String REL = "abc123";
+
+        try {
+            required(null, REL);
+            fail("Should have thrown an exception");
+        } catch (final NullPointerException e) {
+            assertTrue("Exception should mention the relation name.  Message was " + e.getMessage(), e.getMessage()
+                    .contains(REL));
+        }
+    }
+
+    @Test
+    public void requiredLinkRelNotPresentTest() {
+
+        final URI uri = randomUri();
+
+        try {
+            required(uri, null);
+            fail("Should have thrown an exception");
+        } catch (final NullPointerException e) {
+            assertTrue("Exception should mention the link uri.  Message was " + e.getMessage(), e.getMessage()
+                    .contains(uri.toString()));
+        }
+    }
+
+    @Test
+    public void concatenateTest() {
+        final Collection<Link> links1 = asList(
+                new Link(randomUri(), "rel1"),
+                new Link(randomUri(), "rel2"));
+
+        final Collection<Link> links2 = asList(
+                new Link(randomUri(), "rel1"),
+                new Link(randomUri(), "rel2"));
+
+        final List<Link> concatenated = concat(links1.stream(), links2.stream(), empty(), null).collect(toList());
+
+        assertEquals(links1.size() + links2.size(), concatenated.size());
+        assertTrue(concatenated.containsAll(links1));
+        assertTrue(concatenated.containsAll(links2));
+    }
+
+    private URI randomUri() {
+        return URI.create("urn:uuid:" + UUID.randomUUID().toString());
+    }
+}

--- a/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/LinksTest.java
+++ b/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/LinksTest.java
@@ -140,7 +140,7 @@ public class LinksTest {
         assertTrue(concatenated.containsAll(links2));
     }
 
-    private URI randomUri() {
+    static URI randomUri() {
         return URI.create("urn:uuid:" + UUID.randomUUID().toString());
     }
 }

--- a/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/SubmissionLinkAnalyzerTest.java
+++ b/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/SubmissionLinkAnalyzerTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.notification.impl;
+
+import static java.util.stream.Collectors.toList;
+import static org.dataconservancy.pass.model.SubmissionEvent.EventType.APPROVAL_REQUESTED;
+import static org.dataconservancy.pass.model.SubmissionEvent.EventType.APPROVAL_REQUESTED_NEWUSER;
+import static org.dataconservancy.pass.model.SubmissionEvent.EventType.CANCELLED;
+import static org.dataconservancy.pass.model.SubmissionEvent.EventType.CHANGES_REQUESTED;
+import static org.dataconservancy.pass.model.SubmissionEvent.EventType.SUBMITTED;
+import static org.dataconservancy.pass.notification.impl.LinksTest.randomUri;
+import static org.dataconservancy.pass.notification.model.Link.Rels.SUBMISSION_REVIEW;
+import static org.dataconservancy.pass.notification.model.Link.Rels.SUBMISSION_REVIEW_INVITE;
+import static org.dataconservancy.pass.notification.model.Link.Rels.SUBMISSION_VIEW;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import org.dataconservancy.pass.model.Submission;
+import org.dataconservancy.pass.model.SubmissionEvent;
+import org.dataconservancy.pass.notification.model.Link;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author apb@jhu.edu
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SubmissionLinkAnalyzerTest {
+
+    @Mock
+    UserTokenGenerator userTokenGenerator;
+
+    private final Submission submission = new Submission();
+
+    private final SubmissionEvent event = new SubmissionEvent();
+
+    private List<Link> linksGivenToTokenGeneratorFunction;
+
+    private List<Link> linksTransformedByTokenGeneratorFunction;
+
+    private SubmissionLinkAnalyzer toTest;
+
+    @Before
+    public void setUp() {
+        toTest = new SubmissionLinkAnalyzer(userTokenGenerator);
+
+        submission.setId(randomUri());
+        event.setId(randomUri());
+        event.setLink(randomUri());
+
+        // Capture links given to the token generator service, and the transformed results
+        linksGivenToTokenGeneratorFunction = new ArrayList<>();
+        linksTransformedByTokenGeneratorFunction = new ArrayList<>();
+
+        when(userTokenGenerator.forSubmission(any())).thenAnswer(i -> {
+
+            return (UnaryOperator<Link>) link -> {
+                linksGivenToTokenGeneratorFunction.add(link);
+                if (SUBMISSION_REVIEW_INVITE.equals(link.getRel())) {
+                    final Link transformed = new Link(randomUri(), SUBMISSION_REVIEW_INVITE);
+                    linksTransformedByTokenGeneratorFunction.add(transformed);
+                    return transformed;
+                }
+                return link;
+            };
+        });
+    }
+
+    @Test
+    public void aprovalRequestedNewUserTest() {
+
+        event.setEventType(APPROVAL_REQUESTED_NEWUSER);
+
+        final List<Link> generatedLinks = toTest.apply(submission, event).collect(toList());
+
+        verify(userTokenGenerator).forSubmission(eq(submission));
+
+        // Verify that the link generator service was at least given the expected invite link
+        final Link originalInviteLink = new Link(event.getLink(), SUBMISSION_REVIEW_INVITE);
+        assertTrue(linksGivenToTokenGeneratorFunction.contains(originalInviteLink));
+
+        // Verify that the link generator service produced a transformed link
+        // (i.e. the event link, as transformed by token generator).
+        assertTrue(generatedLinks.containsAll(linksTransformedByTokenGeneratorFunction));
+
+        assertEquals(1, generatedLinks.size());
+        assertEquals(SUBMISSION_REVIEW_INVITE, generatedLinks.get(0).getRel());
+    }
+
+    @Test
+    public void aprovalRequestedNewUserLinkMissingTest() {
+        event.setLink(null);
+        event.setEventType(APPROVAL_REQUESTED_NEWUSER);
+
+        try {
+            toTest.apply(submission, event);
+            fail("Should have thrown an exception");
+        } catch (final NullPointerException e) {
+            // The error message should identify the offending submissionEvent
+            assertTrue(e.getMessage().contains(event.getId().toString()));
+        }
+    }
+
+    @Test
+    public void approvalRequestedExistingUserTest() {
+        event.setEventType(APPROVAL_REQUESTED);
+
+        final List<Link> generatedLinks = toTest.apply(submission, event).collect(toList());
+
+        assertEquals(1, generatedLinks.size());
+        assertEquals(event.getLink(), generatedLinks.get(0).getHref());
+        assertEquals(SUBMISSION_REVIEW, generatedLinks.get(0).getRel());
+    }
+
+    @Test
+    public void aprovalRequestedExistingUserLinkMissingTest() {
+        event.setLink(null);
+        event.setEventType(APPROVAL_REQUESTED);
+
+        try {
+            toTest.apply(submission, event);
+            fail("Should have thrown an exception");
+        } catch (final NullPointerException e) {
+            // The error message should identify the offending submissionEvent
+            assertTrue(e.getMessage().contains(event.getId().toString()));
+        }
+    }
+
+    @Test
+    public void changesRequestedTest() {
+        event.setEventType(CHANGES_REQUESTED);
+
+        final List<Link> generatedLinks = toTest.apply(submission, event).collect(toList());
+
+        assertEquals(1, generatedLinks.size());
+        assertEquals(event.getLink(), generatedLinks.get(0).getHref());
+        assertEquals(SUBMISSION_REVIEW, generatedLinks.get(0).getRel());
+    }
+
+    @Test
+    public void changesRequestedLinkMissingTest() {
+        event.setEventType(CHANGES_REQUESTED);
+        event.setLink(null);
+
+        try {
+            toTest.apply(submission, event);
+            fail("Should have thrown an exception");
+        } catch (final NullPointerException e) {
+            // The error message should identify the offending submissionEvent
+            assertTrue(e.getMessage().contains(event.getId().toString()));
+        }
+    }
+
+    @Test
+    public void submittedTest() {
+        event.setEventType(SUBMITTED);
+
+        final List<Link> generatedLinks = toTest.apply(submission, event).collect(toList());
+
+        assertEquals(1, generatedLinks.size());
+        assertEquals(event.getLink(), generatedLinks.get(0).getHref());
+        assertEquals(SUBMISSION_VIEW, generatedLinks.get(0).getRel());
+    }
+
+    @Test
+    public void submitteOptionalLinkMissingTest() {
+        event.setEventType(SUBMITTED);
+        event.setLink(null);
+
+        assertTrue(toTest.apply(submission, event).collect(toList()).isEmpty());
+    }
+
+    @Test
+    public void cancelledTest() {
+        event.setEventType(CANCELLED);
+
+        final List<Link> generatedLinks = toTest.apply(submission, event).collect(toList());
+
+        assertEquals(1, generatedLinks.size());
+        assertEquals(event.getLink(), generatedLinks.get(0).getHref());
+        assertEquals(SUBMISSION_VIEW, generatedLinks.get(0).getRel());
+    }
+
+    @Test
+    public void cancelledOptionalLinkMissingTest() {
+        event.setEventType(CANCELLED);
+        event.setLink(null);
+
+        assertTrue(toTest.apply(submission, event).collect(toList()).isEmpty());
+    }
+
+    @Test
+    public void nullSubmissionEventTest() {
+        event.setEventType(null);
+        event.setLink(null);
+
+        assertTrue(toTest.apply(submission, event).collect(toList()).isEmpty());
+    }
+}

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -51,7 +51,7 @@
                 </property>
             </activation>
             <properties>
-                <mail.waitms>60000</mail.waitms>
+                <mail.waitms>120000</mail.waitms>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Adds submission link generation to the Composer, populating the `LINKS` param of the `Notification` as appropriate.

Resolves #20 