### PR TITLE
Integration of oapass/docker-mailserver, oapass/ldap

### DIFF
--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -31,6 +31,8 @@
     <properties>
         <mail.skip>false</mail.skip>
         <fcrepo.skip>false</fcrepo.skip>
+        <ldap.skip>false</ldap.skip>
+        <ldap.waitms>5000</ldap.waitms>
         <mail.server>${docker.host.address}</mail.server>
         <mail.waitms>15000</mail.waitms>
         <fcrepo.server>${docker.host.address}</fcrepo.server>
@@ -52,6 +54,7 @@
             </activation>
             <properties>
                 <mail.waitms>120000</mail.waitms>
+                <ldap.waitms>30000</ldap.waitms>
             </properties>
         </profile>
     </profiles>
@@ -102,8 +105,6 @@
                         <pass.notification.smtp.port>${mail.smtp.port}</pass.notification.smtp.port>
 
                         <!-- IMAP properties for ITs -->
-                        <mail.imap.user>emetsger@mail.local.domain</mail.imap.user>
-                        <mail.imap.password>moo</mail.imap.password>
                         <mail.imap.host>${mail.server}</mail.imap.host>
                         <mail.imap.port>${mail.imaps.port}</mail.imap.port>
                         <mail.imap.ssl.enable>true</mail.imap.ssl.enable>
@@ -111,6 +112,10 @@
                         <mail.imap.starttls.enable>true</mail.imap.starttls.enable>
                         <mail.imap.finalizecleanclose>false</mail.imap.finalizecleanclose>
 
+                        <!-- Default username / password when connecting to IMAP -->
+                        <!-- Override by setting the desired credentials on the SimpleImapClientFactory -->
+                        <mail.imap.user>staffwithnogrants@jhu.edu</mail.imap.user>
+                        <mail.imap.password>moo</mail.imap.password>
                     </systemProperties>
                 </configuration>
                 <executions>
@@ -194,6 +199,17 @@
                                     <FCREPO_JMS_BASEURL>http://${fcrepo.server}:${fcrepo.http.port}/fcrepo/rest/
                                     </FCREPO_JMS_BASEURL>
                                 </env>
+                            </run>
+                        </image>
+
+                        <image>
+                            <alias>ldap</alias>
+                            <name>${docker.ldap.version}</name>
+                            <run>
+                                <skip>${ldap.skip}</skip>
+                                <wait>
+                                    <time>${ldap.waitms}</time>
+                                </wait>
                             </run>
                         </image>
 

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -102,7 +102,7 @@
                         <es.host>${es.server}</es.host>
                         <es.port>${es.http.port}</es.port>
                         <pass.notification.smtp.host>${mail.server}</pass.notification.smtp.host>
-                        <pass.notification.smtp.port>${mail.smtp.port}</pass.notification.smtp.port>
+                        <pass.notification.smtp.port>${mail.msp.port}</pass.notification.smtp.port>
 
                         <!-- IMAP properties for ITs -->
                         <mail.imap.host>${mail.server}</mail.imap.host>

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -53,8 +53,8 @@
                 </property>
             </activation>
             <properties>
-                <mail.waitms>120000</mail.waitms>
-                <ldap.waitms>30000</ldap.waitms>
+                <mail.waitms>30000</mail.waitms>
+                <ldap.waitms>15000</ldap.waitms>
             </properties>
         </profile>
     </profiles>

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -205,11 +205,9 @@
                                     <FCREPO_PORT>${fcrepo.http.port}</FCREPO_PORT>
                                     <FCREPO_JMS_PORT>${fcrepo.jms.port}</FCREPO_JMS_PORT>
                                     <FCREPO_STOMP_PORT>${fcrepo.stomp.port}</FCREPO_STOMP_PORT>
-                                    <FCREPO_ACTIVEMQ_CONFIGURATION>classpath:/activemq-queue.xml
-                                    </FCREPO_ACTIVEMQ_CONFIGURATION>
+                                    <FCREPO_ACTIVEMQ_CONFIGURATION>classpath:/activemq-queue.xml</FCREPO_ACTIVEMQ_CONFIGURATION>
                                     <FCREPO_LOG_LEVEL>DEBUG</FCREPO_LOG_LEVEL>
-                                    <FCREPO_JMS_BASEURL>http://${fcrepo.server}:${fcrepo.http.port}/fcrepo/rest/
-                                    </FCREPO_JMS_BASEURL>
+                                    <FCREPO_JMS_BASEURL>http://${fcrepo.server}:${fcrepo.http.port}/fcrepo/rest/</FCREPO_JMS_BASEURL>
                                 </env>
                             </run>
                         </image>

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -155,6 +155,9 @@
                                         <volume>mailstate:/var/mail-state</volume>
                                     </bind>
                                 </volumes>
+                                <links>
+                                    <link>ldap</link>
+                                </links>
                                 <env>
                                     <HOSTNAME>mail</HOSTNAME>
                                     <DOMAINNAME>jhu.edu</DOMAINNAME>

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -146,8 +146,6 @@
                                 <hostname>mail</hostname>
                                 <domainname>local.domain</domainname>
                                 <ports>
-                                    <port>${mail.smtp.port}:25</port>
-                                    <port>${mail.imap.port}:143</port>
                                     <port>${mail.imaps.port}:993</port>
                                     <port>${mail.msp.port}:587</port>
                                 </ports>

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -78,7 +78,7 @@
                                 <portName>mail.smtp.port</portName>
                                 <portName>mail.imap.port</portName>
                                 <portName>mail.imaps.port</portName>
-                                <portName>mail.msp.tls.port</portName>
+                                <portName>mail.msp.port</portName>
                                 <portName>fcrepo.http.port</portName>
                                 <portName>fcrepo.jms.port</portName>
                                 <portName>fcrepo.stomp.port</portName>
@@ -149,7 +149,7 @@
                                     <port>${mail.smtp.port}:25</port>
                                     <port>${mail.imap.port}:143</port>
                                     <port>${mail.imaps.port}:993</port>
-                                    <port>${mail.msp.tls.port}:587</port>
+                                    <port>${mail.msp.port}:587</port>
                                 </ports>
                                 <volumes>
                                     <bind>

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -157,14 +157,28 @@
                                 </volumes>
                                 <env>
                                     <HOSTNAME>mail</HOSTNAME>
-                                    <DOMAINNAME>local.domain</DOMAINNAME>
+                                    <DOMAINNAME>jhu.edu</DOMAINNAME>
                                     <DMS_DEBUG>0</DMS_DEBUG>
                                     <ONE_DIR>1</ONE_DIR>
                                     <SMTP_ONLY>0</SMTP_ONLY>
                                     <PERMIT_DOCKER>network</PERMIT_DOCKER>
-                                    <OVERRIDE_HOSTNAME>mail.local.domain</OVERRIDE_HOSTNAME>
+                                    <OVERRIDE_HOSTNAME>mail.jhu.edu</OVERRIDE_HOSTNAME>
                                     <TLS_LEVEL>intermediate</TLS_LEVEL>
                                     <ENABLE_SPAMASSASSIN>0</ENABLE_SPAMASSASSIN>
+                                    <ENABLE_CLAMAV>0</ENABLE_CLAMAV>
+                                    <ENABLE_FAIL2BAN>0</ENABLE_FAIL2BAN>
+                                    <ENABLE_POSTGREY>0</ENABLE_POSTGREY>
+                                    <ENABLE_SASLAUTHD>0</ENABLE_SASLAUTHD>
+                                    <POSTMASTER_ADDRESS>root</POSTMASTER_ADDRESS>
+                                    <ENABLE_LDAP>1</ENABLE_LDAP>
+                                    <LDAP_SERVER_HOST>ldap</LDAP_SERVER_HOST>
+                                    <LDAP_SEARCH_BASE>ou=People,dc=pass</LDAP_SEARCH_BASE>
+                                    <LDAP_BIND_DN>cn=admin,dc=pass</LDAP_BIND_DN>
+                                    <LDAP_BIND_PW>password</LDAP_BIND_PW>
+                                    <LDAP_QUERY_FILTER_USER>(&amp;(objectClass=posixAccount)(mail=%s))</LDAP_QUERY_FILTER_USER>
+                                    <LDAP_QUERY_FILTER_GROUP>(&amp;(objectClass=posixAccount)(mailGroupMember=%s))</LDAP_QUERY_FILTER_GROUP>
+                                    <LDAP_QUERY_FILTER_ALIAS>(&amp;(objectClass=posixAccount)(mailAlias=%s))</LDAP_QUERY_FILTER_ALIAS>
+                                    <LDAP_QUERY_FILTER_DOMAIN>(|(mail=*@%s)(mailalias=*@%s)(mailGroupMember=*@%s))</LDAP_QUERY_FILTER_DOMAIN>
                                 </env>
                             </run>
                         </image>

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactory.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactory.java
@@ -72,19 +72,21 @@ public class SimpleImapClientFactory implements FactoryBean<SimpleImapClient> {
 
     @Override
     public SimpleImapClient getObject() throws Exception {
-        try {
-            LOG.trace("Connecting to IMAP host '{}' store '{}@{}' with username '{}'",
-                    imapHost,
-                    imapStore.getClass().getName(),
-                    Integer.toHexString(System.identityHashCode(imapStore)),
-                    imapUser);
-            imapStore.connect(imapHost, imapUser, imapPass);
-            LOG.trace("Store '{}@{}' connected? '{}'",
-                    imapStore.getClass().getName(),
-                    Integer.toHexString(System.identityHashCode(imapStore)),
-                    imapStore.isConnected());
-        } catch (MessagingException e) {
-            throw new RuntimeException(e);
+        if (!imapStore.isConnected()) {
+            try {
+                LOG.trace("Connecting to IMAP host '{}' store '{}@{}' with username '{}'",
+                        imapHost,
+                        imapStore.getClass().getName(),
+                        Integer.toHexString(System.identityHashCode(imapStore)),
+                        imapUser);
+                imapStore.connect(imapHost, imapUser, imapPass);
+                LOG.trace("Store '{}@{}' connected? '{}'",
+                        imapStore.getClass().getName(),
+                        Integer.toHexString(System.identityHashCode(imapStore)),
+                        imapStore.isConnected());
+            } catch (MessagingException e) {
+                throw new RuntimeException(e);
+            }
         }
         return new SimpleImapClient(session, imapStore);
     }

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactory.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactory.java
@@ -73,13 +73,13 @@ public class SimpleImapClientFactory implements FactoryBean<SimpleImapClient> {
     @Override
     public SimpleImapClient getObject() throws Exception {
         try {
-            LOG.warn("Connecting to IMAP host '{}' store '{}@{}' with username '{}'",
+            LOG.trace("Connecting to IMAP host '{}' store '{}@{}' with username '{}'",
                     imapHost,
                     imapStore.getClass().getName(),
                     Integer.toHexString(System.identityHashCode(imapStore)),
                     imapUser);
             imapStore.connect(imapHost, imapUser, imapPass);
-            LOG.warn("Store '{}@{}' connected? '{}'",
+            LOG.trace("Store '{}@{}' connected? '{}'",
                     imapStore.getClass().getName(),
                     Integer.toHexString(System.identityHashCode(imapStore)),
                     imapStore.isConnected());

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactory.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactory.java
@@ -17,6 +17,8 @@ package org.dataconservancy.pass.notification;
 
 import com.sun.mail.imap.IMAPStore;
 import org.dataconservancy.pass.notification.util.mail.SimpleImapClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,9 +33,14 @@ import javax.mail.Session;
 @Configuration
 public class SimpleImapClientFactory implements FactoryBean<SimpleImapClient> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(SimpleImapClientFactory.class);
+
     private IMAPStore imapStore;
 
     private Session session;
+
+    @Value("${mail.imap.host}")
+    private String imapHost;
 
     @Value("${mail.imap.user}")
     private String imapUser;
@@ -66,7 +73,16 @@ public class SimpleImapClientFactory implements FactoryBean<SimpleImapClient> {
     @Override
     public SimpleImapClient getObject() throws Exception {
         try {
-            imapStore.connect(imapUser, imapPass);
+            LOG.warn("Connecting to IMAP host '{}' store '{}@{}' with username '{}'",
+                    imapHost,
+                    imapStore.getClass().getName(),
+                    Integer.toHexString(System.identityHashCode(imapStore)),
+                    imapUser);
+            imapStore.connect(imapHost, imapUser, imapPass);
+            LOG.warn("Store '{}@{}' connected? '{}'",
+                    imapStore.getClass().getName(),
+                    Integer.toHexString(System.identityHashCode(imapStore)),
+                    imapStore.isConnected());
         } catch (MessagingException e) {
             throw new RuntimeException(e);
         }

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactory.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.notification;
+
+import com.sun.mail.imap.IMAPStore;
+import org.dataconservancy.pass.notification.util.mail.SimpleImapClient;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import javax.mail.MessagingException;
+import javax.mail.Session;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@Configuration
+public class SimpleImapClientFactory implements FactoryBean<SimpleImapClient> {
+
+    private IMAPStore imapStore;
+
+    private Session session;
+
+    @Value("${mail.imap.user}")
+    private String imapUser;
+
+    @Value("${mail.imap.password}")
+    private String imapPass;
+
+    @Autowired
+    public SimpleImapClientFactory(IMAPStore imapStore, Session session) {
+        this.imapStore = imapStore;
+        this.session = session;
+    }
+
+    public String getImapUser() {
+        return imapUser;
+    }
+
+    public void setImapUser(String imapUser) {
+        this.imapUser = imapUser;
+    }
+
+    public String getImapPass() {
+        return imapPass;
+    }
+
+    public void setImapPass(String imapPass) {
+        this.imapPass = imapPass;
+    }
+
+    @Override
+    public SimpleImapClient getObject() throws Exception {
+        try {
+            imapStore.connect(imapUser, imapPass);
+        } catch (MessagingException e) {
+            throw new RuntimeException(e);
+        }
+        return new SimpleImapClient(session, imapStore);
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return SimpleImapClient.class;
+    }
+}

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactoryConfiguration.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactoryConfiguration.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.notification;
+
+import com.sun.mail.imap.IMAPStore;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import java.util.Properties;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@Configuration
+public class SimpleImapClientFactoryConfiguration {
+
+    @Value("${mail.imap.user}")
+    private String imapUser;
+
+    @Value("${mail.imap.password}")
+    private String imapPass;
+
+    @Value("${mail.imap.host}")
+    private String imapHost;
+
+    @Value("${mail.imap.port}")
+    private String imapPort;
+
+    @Value("${mail.imap.ssl.enable}")
+    private boolean useSsl;
+
+    @Value("${mail.imap.ssl.trust}")
+    private String sslTrust;
+
+    @Value("${mail.imap.starttls.enable}")
+    private boolean enableTlsIfSupported;
+
+    @Value("${mail.imap.finalizecleanclose}")
+    private boolean closeOnFinalize;
+
+    @Bean
+    public Session mailSession() {
+        return Session.getDefaultInstance(new Properties() {
+            {
+                put("mail.imap.host", imapHost);
+                put("mail.imap.port", imapPort);
+                put("mail.imap.ssl.enable", useSsl);
+                put("mail.imap.ssl.trust", sslTrust);
+                put("mail.imap.starttls.enable", enableTlsIfSupported);
+                put("mail.imap.finalizecleanclose", closeOnFinalize);
+            }
+        });
+    }
+
+    @Bean
+    public IMAPStore imapStore(Session session) {
+        try {
+            return (IMAPStore) session.getStore("imap");
+        } catch (MessagingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactoryConfiguration.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactoryConfiguration.java
@@ -17,8 +17,10 @@ package org.dataconservancy.pass.notification;
 
 import com.sun.mail.imap.IMAPStore;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 
 import javax.mail.MessagingException;
 import javax.mail.Session;
@@ -69,6 +71,7 @@ public class SimpleImapClientFactoryConfiguration {
     }
 
     @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public IMAPStore imapStore(Session session) {
         try {
             return (IMAPStore) session.getStore("imap");

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/SpringBootIntegrationConfig.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/SpringBootIntegrationConfig.java
@@ -15,15 +15,7 @@
  */
 package org.dataconservancy.pass.notification;
 
-import com.sun.mail.imap.IMAPStore;
-import org.dataconservancy.pass.notification.util.mail.SimpleImapClient;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import java.util.Properties;
 
 /**
  * @author Elliot Metsger (emetsger@jhu.edu)
@@ -31,58 +23,4 @@ import java.util.Properties;
 @Configuration
 public class SpringBootIntegrationConfig {
 
-    @Value("${mail.imap.user}")
-    private String imapUser;
-
-    @Value("${mail.imap.password}")
-    private String imapPass;
-
-    @Value("${mail.imap.host}")
-    private String imapHost;
-
-    @Value("${mail.imap.port}")
-    private String imapPort;
-
-    @Value("${mail.imap.ssl.enable}")
-    private boolean useSsl;
-
-    @Value("${mail.imap.ssl.trust}")
-    private String sslTrust;
-
-    @Value("${mail.imap.starttls.enable}")
-    private boolean enableTlsIfSupported;
-
-    @Value("${mail.imap.finalizecleanclose}")
-    private boolean closeOnFinalize;
-
-    @Bean
-    public Session mailSession() {
-        return Session.getDefaultInstance(new Properties() {
-            {
-                put("mail.imap.user", imapUser);
-                put("mail.imap.host", imapHost);
-                put("mail.imap.port", imapPort);
-                put("mail.imap.ssl.enable", useSsl);
-                put("mail.imap.ssl.trust", sslTrust);
-                put("mail.imap.starttls.enable", enableTlsIfSupported);
-                put("mail.imap.finalizecleanclose", closeOnFinalize);
-            }
-        });
-    }
-
-    @Bean
-    public IMAPStore imapStore(Session session) {
-        try {
-            IMAPStore store = (IMAPStore)session.getStore("imap");
-            store.connect(imapUser, imapPass);
-            return store;
-        } catch (MessagingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Bean
-    public SimpleImapClient imapClient(Session session, IMAPStore store) {
-        return new SimpleImapClient(session, store);
-    }
 }

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
@@ -55,7 +55,7 @@ import static java.util.Arrays.asList;
 import static org.apache.commons.io.IOUtils.resourceToString;
 import static org.dataconservancy.pass.notification.impl.Links.serialized;
 import static org.dataconservancy.pass.notification.model.Link.Rels.SUBMISSION_REVIEW_INVITE;
-import static org.dataconservancy.pass.notification.model.Notification.Param.LINKS
+import static org.dataconservancy.pass.notification.model.Notification.Param.LINKS;
 import static org.dataconservancy.pass.notification.model.Notification.Param.EVENT_METADATA;
 import static org.dataconservancy.pass.notification.model.Notification.Param.FROM;
 import static org.dataconservancy.pass.notification.model.Notification.Param.RESOURCE_METADATA;

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
@@ -115,7 +115,7 @@ public class EmailDispatchImplIT {
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
         n.setSender(SENDER);
-//        n.setCc(Collections.singleton(CC));
+        n.setCc(Collections.singleton(CC));
         n.setRecipient(Collections.singleton("mailto:" + RECIPIENT));
 
         String messageId = underTest.dispatch(n);
@@ -128,7 +128,7 @@ public class EmailDispatchImplIT {
         assertEquals("Approval Invite Subject", message.getSubject());
         assertEquals(expectedBody, getBodyAsText(message));
         assertEquals(SENDER, message.getFrom()[0].toString());
-//        assertEquals(CC, message.getRecipients(Message.RecipientType.CC)[0].toString());
+        assertEquals(CC, message.getRecipients(Message.RecipientType.CC)[0].toString());
         assertEquals(RECIPIENT, message.getRecipients(Message.RecipientType.TO)[0].toString());
     }
 

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
@@ -271,7 +271,9 @@ public class EmailDispatchImplIT {
     }
 
     private static Condition<Message> newMessageCondition(String messageId, SimpleImapClient imapClient) {
-        return new Condition<>(getMessage(messageId, imapClient), Objects::nonNull, "New message");
+        Condition<Message> c = new Condition<>(getMessage(messageId, imapClient), Objects::nonNull, "New message");
+        c.setTimeoutThresholdMs(10000);
+        return c;
     }
 
     private static Callable<Message> getMessage(String messageId, SimpleImapClient imapClient) {

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
@@ -16,11 +16,11 @@
 package org.dataconservancy.pass.notification.dispatch.impl.email;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.IOUtils;
 import org.dataconservancy.pass.client.PassClient;
 import org.dataconservancy.pass.model.Submission;
 import org.dataconservancy.pass.model.SubmissionEvent;
 import org.dataconservancy.pass.model.User;
+import org.dataconservancy.pass.notification.SimpleImapClientFactory;
 import org.dataconservancy.pass.notification.SpringBootIntegrationConfig;
 import org.dataconservancy.pass.notification.app.NotificationApp;
 import org.dataconservancy.pass.notification.impl.Composer;
@@ -33,6 +33,7 @@ import org.dataconservancy.pass.notification.model.config.template.NotificationT
 import org.dataconservancy.pass.notification.util.async.Condition;
 import org.dataconservancy.pass.notification.util.mail.SimpleImapClient;
 import org.joda.time.DateTime;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -43,21 +44,22 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import javax.mail.Message;
-import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 
-import static java.lang.String.join;
 import static java.nio.charset.Charset.forName;
 import static java.util.Arrays.asList;
 import static org.apache.commons.io.IOUtils.resourceToString;
 import static org.dataconservancy.pass.notification.impl.Links.serialized;
 import static org.dataconservancy.pass.notification.model.Link.Rels.SUBMISSION_REVIEW_INVITE;
-import static org.dataconservancy.pass.notification.model.Notification.Param.*;
+import static org.dataconservancy.pass.notification.model.Notification.Param.LINKS
+import static org.dataconservancy.pass.notification.model.Notification.Param.EVENT_METADATA;
+import static org.dataconservancy.pass.notification.model.Notification.Param.FROM;
+import static org.dataconservancy.pass.notification.model.Notification.Param.RESOURCE_METADATA;
+import static org.dataconservancy.pass.notification.model.Notification.Param.TO;
 import static org.dataconservancy.pass.notification.model.Notification.Type.SUBMISSION_APPROVAL_INVITE;
 import static org.dataconservancy.pass.notification.util.mail.SimpleImapClient.getBodyAsText;
 import static org.junit.Assert.assertEquals;
@@ -73,6 +75,12 @@ public class EmailDispatchImplIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(EmailDispatchImplIT.class);
 
+    private static final String SENDER = "staffWithGrants@jhu.edu";
+
+    private static final String RECIPIENT = "staffWithNoGrants@jhu.edu";
+
+    private static final String CC = "facultyWithGrants@jhu.edu";
+
     @Autowired
     private EmailDispatchImpl underTest;
 
@@ -80,7 +88,7 @@ public class EmailDispatchImplIT {
     private PassClient passClient;
 
     @Autowired
-    private SimpleImapClient imapClient;
+    private SimpleImapClientFactory imapClientFactory;
 
     @Autowired
     private NotificationConfig config;
@@ -88,21 +96,27 @@ public class EmailDispatchImplIT {
     @Autowired
     private ObjectMapper objectMapper;
 
+    private SimpleImapClient imapClient;
+
+    @Before
+    public void setUp() throws Exception {
+        imapClientFactory.setImapUser(RECIPIENT);
+        imapClientFactory.setImapPass("moo");
+        imapClient = imapClientFactory.getObject();
+    }
+
     /**
      * Simple test insuring the basic parts of the dispatch email are where they belong.
      */
     @Test
     public void simpleSuccess() throws Exception {
-        String sender = "preparer@mail.local.domain";
-        String cc = "cc@mail.local.domain";
-        String recipient = "emetsger@mail.local.domain";
         String expectedBody = "Approval Invite Body\r\n\r\nApproval Invite Footer";
 
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
-        n.setSender(sender);
-        n.setCc(Collections.singleton(cc));
-        n.setRecipient(Collections.singleton("mailto:" + recipient));
+        n.setSender(SENDER);
+//        n.setCc(Collections.singleton(CC));
+        n.setRecipient(Collections.singleton("mailto:" + RECIPIENT));
 
         String messageId = underTest.dispatch(n);
         assertNotNull(messageId);
@@ -113,9 +127,9 @@ public class EmailDispatchImplIT {
 
         assertEquals("Approval Invite Subject", message.getSubject());
         assertEquals(expectedBody, getBodyAsText(message));
-        assertEquals(sender, message.getFrom()[0].toString());
-        assertEquals(cc, message.getRecipients(Message.RecipientType.CC)[0].toString());
-        assertEquals(recipient, message.getRecipients(Message.RecipientType.TO)[0].toString());
+        assertEquals(SENDER, message.getFrom()[0].toString());
+//        assertEquals(CC, message.getRecipients(Message.RecipientType.CC)[0].toString());
+        assertEquals(RECIPIENT, message.getRecipients(Message.RecipientType.TO)[0].toString());
     }
 
     /**
@@ -123,16 +137,13 @@ public class EmailDispatchImplIT {
      */
     @Test
     public void dispatchResolveUserUri() throws Exception {
-        String sender = "preparer@mail.local.domain";
-        String recipient = "emetsger@mail.local.domain";
-
         User recipientUser = new User();
-        recipientUser.setEmail(recipient);
+        recipientUser.setEmail(RECIPIENT);
         URI recipientUri = passClient.createResource(recipientUser);
 
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
-        n.setSender(sender);
+        n.setSender(SENDER);
         n.setRecipient(Collections.singleton(recipientUri.toString()));
 
         String messageId = underTest.dispatch(n);
@@ -140,7 +151,7 @@ public class EmailDispatchImplIT {
         newMessageCondition(messageId, imapClient).await();
         Message message = getMessage(messageId, imapClient).call();
 
-        assertEquals(recipient, message.getRecipients(Message.RecipientType.TO)[0].toString());
+        assertEquals(RECIPIENT, message.getRecipients(Message.RecipientType.TO)[0].toString());
     }
 
     /**
@@ -170,8 +181,8 @@ public class EmailDispatchImplIT {
 
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
-        n.setSender("preparer@mail.local.domain");
-        n.setRecipient(Collections.singleton("mailto:emetsger@mail.local.domain"));
+        n.setSender(SENDER);
+        n.setRecipient(Collections.singleton("mailto:" + RECIPIENT));
 
         String messageId = underTest.dispatch(n);
         assertNotNull(messageId);
@@ -219,16 +230,14 @@ public class EmailDispatchImplIT {
 
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
-        String sender = "preparer@mail.local.domain";
-        n.setSender(sender);
-        String recipient = "emetsger@mail.local.domain";
-        n.setRecipient(Collections.singleton("mailto:" + recipient));
+        n.setSender(SENDER);
+        n.setRecipient(Collections.singleton("mailto:" + RECIPIENT));
         n.setParameters(new HashMap<Notification.Param, String>() {
             {
                 put(RESOURCE_METADATA, Composer.resourceMetadata(submission, objectMapper));
                 put(EVENT_METADATA, Composer.eventMetadata(event, objectMapper));
-                put(FROM, sender);
-                put(TO, recipient);
+                put(FROM, SENDER);
+                put(TO, RECIPIENT);
                 put(LINKS, asList(link).stream().collect(serialized()));
             }
         });

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/util/mail/SimpleImapClient.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/util/mail/SimpleImapClient.java
@@ -53,6 +53,10 @@ public class SimpleImapClient {
     public SimpleImapClient(Session mailSession, IMAPStore store) {
         this.mailSession = mailSession;
         this.store = store;
+        LOG.trace("Constructed store '{}@{}' isConnected? '{}'",
+                store.getClass().getName(),
+                Integer.toHexString(System.identityHashCode(store)),
+                store.isConnected());
     }
 
     /**
@@ -67,9 +71,17 @@ public class SimpleImapClient {
 
         MessageIDTerm idTerm = new MessageIDTerm(messageId);
 
+        LOG.trace("Store '{}@{}' isConnected? '{}'",
+                store.getClass().getName(),
+                Integer.toHexString(System.identityHashCode(store)),
+                store.isConnected());
+
         return getFolders().stream().filter(folder -> folder.getName().length() > 0).flatMap(folder -> {
             try {
-                LOG.trace("Opening folder '{}'", folder.getName());
+                LOG.trace("Store '{}@{}' opening folder '{}'",
+                        store.getClass().getName(),
+                        Integer.toHexString(System.identityHashCode(store)),
+                        folder.getName());
                 folder.open(Folder.READ_ONLY);
                 Message[] messages = folder.search(idTerm);
                 if (messages != null && messages.length > 0) {

--- a/notification-integration/src/test/resources/logback-test.xml
+++ b/notification-integration/src/test/resources/logback-test.xml
@@ -45,6 +45,10 @@
     <logger name="NOTIFICATION_LOG" additivity="false" level="${org.dataconservancy.pass.notification.level:-INFO}">
         <appender-ref ref="STDERR"/>
     </logger>
+
+    <logger name="com.sun.mail.imap" additivity="false" level="${com.sun.mail.imap.level:-WARN}">
+        <appender-ref ref="STDERR"/>
+    </logger>
     <!-- the rest client is noisy, and detracts from looking at test logging output -->
     <logger name="org.elasticsearch.client.RestClient" additivity="false" level="${org.elasticsearch.client.level:-ERROR}">
         <appender-ref ref="STDERR"/>

--- a/notification-integration/src/test/resources/logback-test.xml
+++ b/notification-integration/src/test/resources/logback-test.xml
@@ -39,7 +39,7 @@
     <logger name="org.dataconservancy.pass" additivity="false" level="${org.dataconservancy.pass.level:-WARN}">
         <appender-ref ref="STDERR"/>
     </logger>
-    <logger name="org.dataconservancy.pass.notification" additivity="false" level="${org.dataconservancy.pass.notification.level:-INFO}">
+    <logger name="org.dataconservancy.pass.notification" additivity="false" level="${org.dataconservancy.pass.notification.level:-TRACE}">
         <appender-ref ref="STDERR"/>
     </logger>
     <logger name="NOTIFICATION_LOG" additivity="false" level="${org.dataconservancy.pass.notification.level:-INFO}">

--- a/notification-integration/src/test/resources/logback-test.xml
+++ b/notification-integration/src/test/resources/logback-test.xml
@@ -39,7 +39,7 @@
     <logger name="org.dataconservancy.pass" additivity="false" level="${org.dataconservancy.pass.level:-WARN}">
         <appender-ref ref="STDERR"/>
     </logger>
-    <logger name="org.dataconservancy.pass.notification" additivity="false" level="${org.dataconservancy.pass.notification.level:-TRACE}">
+    <logger name="org.dataconservancy.pass.notification" additivity="false" level="${org.dataconservancy.pass.notification.level:-INFO}">
         <appender-ref ref="STDERR"/>
     </logger>
     <logger name="NOTIFICATION_LOG" additivity="false" level="${org.dataconservancy.pass.notification.level:-INFO}">

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <docker.fcrepo.version>oapass/fcrepo:4.7.5-3.1</docker.fcrepo.version>
         <docker.indexer.version>oapass/indexer:0.0.15-3.1-SNAPSHOT</docker.indexer.version>
         <docker.elasticsearch.version>docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3</docker.elasticsearch.version>
-        <docker.tvial.docker-mailserver.version>oapass/docker-mailserver:20181024</docker.tvial.docker-mailserver.version>
+        <docker.tvial.docker-mailserver.version>oapass/docker-mailserver:20181025</docker.tvial.docker-mailserver.version>
         <docker.ldap.version>oapass/ldap:20181024</docker.ldap.version>
 
         <pass.jsonld.context>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.1.jsonld</pass.jsonld.context>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <docker.indexer.version>oapass/indexer:0.0.15-3.1-SNAPSHOT</docker.indexer.version>
         <docker.elasticsearch.version>docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3</docker.elasticsearch.version>
         <docker.tvial.docker-mailserver.version>oapass/docker-mailserver:latest</docker.tvial.docker-mailserver.version>
+        <docker.ldap.version>oapass/ldap:20181022</docker.ldap.version>
 
         <pass.jsonld.context>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.1.jsonld</pass.jsonld.context>
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,8 @@
         <docker.fcrepo.version>oapass/fcrepo:4.7.5-3.1</docker.fcrepo.version>
         <docker.indexer.version>oapass/indexer:0.0.15-3.1-SNAPSHOT</docker.indexer.version>
         <docker.elasticsearch.version>docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3</docker.elasticsearch.version>
-        <docker.tvial.docker-mailserver.version>oapass/docker-mailserver:latest</docker.tvial.docker-mailserver.version>
-        <docker.ldap.version>oapass/ldap:20181022</docker.ldap.version>
+        <docker.tvial.docker-mailserver.version>oapass/docker-mailserver:20181024</docker.tvial.docker-mailserver.version>
+        <docker.ldap.version>oapass/ldap:20181024</docker.ldap.version>
 
         <pass.jsonld.context>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.1.jsonld</pass.jsonld.context>
 


### PR DESCRIPTION
Updates the integration environment of Notification Services to use a mail server integrated with ldap.  This allows ITs to send email, receive email, and authenticate to the mail server as `<user>@jhu.edu`, for any defined user in LDAP that has a `mail` attribute ending in `@jhu.edu`.

Includes an IT insuring that the mail server is not an open relay.