### PR TITLE
Use (submissionUri, e-mail) for user tokens

### DIFF
--- a/notification-boot/src/test/java/org/dataconservancy/pass/notification/impl/ComposerIT.java
+++ b/notification-boot/src/test/java/org/dataconservancy/pass/notification/impl/ComposerIT.java
@@ -328,7 +328,16 @@ public class ComposerIT {
             submission.setId(URI.create(submissionId));
             submission.setPreparers(preparers.stream().map(URI::create).collect(Collectors.toList()));
             submission.setSubmitter(URI.create(submitter));
-
+            
+            if (SubmissionEvent.EventType.APPROVAL_REQUESTED_NEWUSER.equals(eventType)) {
+                
+                // TODO:  Add this in once the mechanism of new submitters has been changed
+                // from submitter URIs to submitter email+name
+                //submission.setSubmitter(null);
+                submission.setSubmitterEmail(URI.create("mailto:nobody@example.org"));
+                submission.setSubmitterName("moo!");
+            }
+            
             assertEquals(expectedMapping.get(eventType), composer.apply(submission, event).getType());
         });
     }
@@ -342,7 +351,11 @@ public class ComposerIT {
         String from = "mailto:preparer@mail.local.domain";
 
         Submission submission = new Submission();
+        
+        // TODO:  This needs to be null, once it is possible to do so.
         submission.setSubmitter(URI.create(to));
+        
+        submission.setSubmitterEmail(URI.create(to));
         URI preparerUri = URI.create(from);
         submission.setPreparers(singletonList(preparerUri));
         String metadata = resourceToString(join("/","", packageAsPath(), "submission-metadata.json"), forName("UTF-8"));

--- a/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/UserTokenGenerator.java
+++ b/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/UserTokenGenerator.java
@@ -74,24 +74,27 @@ public class UserTokenGenerator {
         requireNonNull(submission, "Cannot create an invitation link for a null submission");
         requireNonNull(submission.getId(),
                 "Cannot create an invitation link for a submission with a null ID");
-        requireNonNull(submission.getSubmitter(),
-                format("Cannot create an invitation link, Submitter is null on %s", submission.getId()));
 
         return link -> {
             if (SUBMISSION_REVIEW_INVITE.equals(link.getRel())) {
 
+                requireNonNull(submission.getSubmitterEmail(),
+                        format("Cannot create an invitation link, submitter e-mail is null on %s", submission
+                                .getId()));
+
                 LOG.debug("Attaching user token for <{}> to link <{}>",
-                        submission.getSubmitter(),
+                        submission.getSubmitterEmail(),
                         link.getHref());
 
                 final Link inviteLink = new Link(
                         tokenFactory
                                 .forPassResource(submission.getId())
-                                .withReference(submission.getSubmitter())
+                                .withReference(submission.getSubmitterEmail())
                                 .addTo(link.getHref()),
                         link.getRel());
 
-                LOG.info("Generated invitation link <{}> for <{}>", inviteLink.getHref(), submission.getSubmitter());
+                LOG.info("Generated invitation link <{}> for <{}>", inviteLink.getHref(), submission
+                        .getSubmitterEmail());
 
                 return inviteLink;
             } else {

--- a/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/UserTokenGeneratorTest.java
+++ b/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/UserTokenGeneratorTest.java
@@ -61,7 +61,7 @@ public class UserTokenGeneratorTest {
 
     URI submissionUri = URI.create("http://example.org/test/submission");
 
-    URI submitterPlaceholder = URI.create("mailto:test");
+    URI submitterEmail = URI.create("mailto:test");
 
     URI emberLink = URI.create("http://example.org/test/emberLink");
 
@@ -74,10 +74,10 @@ public class UserTokenGeneratorTest {
     @Before
     public void setUp() {
         submission.setId(submissionUri);
-        submission.setSubmitter(submitterPlaceholder);
+        submission.setSubmitterEmail(submitterEmail);
 
         when(tokenFactory.forPassResource(eq(submissionUri))).thenReturn(tokenBuilder);
-        when(tokenBuilder.withReference(eq(submitterPlaceholder))).thenReturn(token);
+        when(tokenBuilder.withReference(eq(submitterEmail))).thenReturn(token);
         when(token.addTo(eq(emberLink))).thenReturn(emberLinkWithToken);
 
         toTest = new UserTokenGenerator(tokenFactory);
@@ -92,7 +92,7 @@ public class UserTokenGeneratorTest {
                 toTest.forSubmission(submission).apply(inviteLink));
 
         verify(tokenFactory, times(1)).forPassResource(eq(submissionUri));
-        verify(tokenBuilder, times(1)).withReference(eq(submitterPlaceholder));
+        verify(tokenBuilder, times(1)).withReference(eq(submitterEmail));
         verify(token, times(1)).addTo(eq(emberLink));
     }
 
@@ -114,10 +114,10 @@ public class UserTokenGeneratorTest {
         assertTrue(processedLinks.containsAll(links));
     }
 
-    // Throw an exception if the submitter is null
+    // Throw an exception if the submitter email is null
     @Test
-    public void noSubmitterTest() {
-        submission.setSubmitter(null);
+    public void noSubmitterEmailTest() {
+        submission.setSubmitterEmail(null);
 
         try {
             toTest.forSubmission(submission).apply(new Link(emberLink, SUBMISSION_REVIEW_INVITE));
@@ -166,6 +166,6 @@ public class UserTokenGeneratorTest {
         final Token decodedToken = decoder.fromUri(inviteWithUserToken.getHref());
 
         assertEquals(submission.getId(), decodedToken.getPassResource());
-        assertEquals(submission.getSubmitter(), decodedToken.getReference());
+        assertEquals(submission.getSubmitterEmail(), decodedToken.getReference());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <sword2-client.version>0.9.3</sword2-client.version>
         <mets-api.version>1.3.0</mets-api.version>
         <tika.version>1.17</tika.version>
-        <pass-client.version>0.4.2</pass-client.version>
+        <pass-client.version>0.5.0</pass-client.version>
         <pass-authz.version>0.3.1</pass-authz.version>
         <fast-classpath-scanner.version>3.1.5</fast-classpath-scanner.version>
         <jackson.version>2.9.6</jackson.version>


### PR DESCRIPTION
Uses client 0.5.0 which updates the data model, and uses a different
approach to identifying new/invited users.

Updates the user token generation logic, and sets submitter name/email
when required in tests.

Resolves #38 