### PR TITLE
Allow configuration of the SMTP transport used

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Notification Services (NS) emits notifications in the form of email.  Therefore 
 - `PASS_NOTIFICATION_SMTP_PORT` (`pass.notification.smtp.port`): the TCP port for SMTP mail relay or submission
 - `PASS_NOTIFICATION_SMTP_USER` (`pass.notification.smtp.user`): optional username for SMTP auth
 - `PASS_NOTIFICATION_SMTP_PASS` (`pass.notification.smtp.pass`): optional password for SMTP auth
-
-**Currently only plain text SMTP communication is supported**.  A future release of NS will allow SMTPS and TLS to be chosen.
+- `PASS_NOTIFICATION_SMTP_TRANSPORT` (`pass.notification.smtp.transport`): valid options are: `SMTP`, `SMTPS`, `SMTP_TLS`
 
 ## Notification Recipients
 
@@ -114,8 +113,9 @@ Supported environment variables (system property analogs) and default values are
 - `PASS_NOTIFICATION_MODE` (`pass.notification.mode`): `DEMO`
 - `PASS_NOTIFICATION_SMTP_HOST` (`pass.notification.smtp.host`): `${pass.notification.smtp.host:localhost}`
 - `PASS_NOTIFICATION_SMTP_PORT` (`pass.notification.smtp.port`): `${pass.notification.smtp.port:587}`
-- `PASS_NOTIFICATION_SMTP_USER` (`pass.notification.smtp.user`): 
-- `PASS_NOTIFICATION_PASS` (`pass.notification.smtp.pass`): 
+- `PASS_NOTIFICATION_SMTP_USER` (`pass.notification.smtp.user`):
+- `PASS_NOTIFICATION_SMTP_PASS` (`pass.notification.smtp.pass`):
+- `PASS_NOTIFICATION_SMTP_TRANSPORT` (`pass.notification.smtp.transport`): `${pass.notification.smtp.transport:SMTP}`  
 - `PASS_NOTIFICATION_MAILER_DEBUG` (`pass.notification.mailer.debug`): `false`
 - `PASS_NOTIFICATION_CONFIGURATION` (`pass.notification.configuration`): `classpath:/notification.json`
 - `PASS_NOTIFICATION_HTTP_AGENT` (`pass.notification.http.agent`): `pass-notification/x.y.z`
@@ -185,7 +185,8 @@ An example configuration file is provided below:
     "host": "${pass.notification.smtp.host}",
     "port": "${pass.notification.smtp.port}",
     "smtpUser": "${pass.notification.smtp.user}",
-    "smtpPassword": "${pass.notification.smtp.pass}"
+    "smtpPassword": "${pass.notification.smtp.pass}",
+    "smtpTransport": "SMTP_TLS"
   },
   "user-token-generator": {
     "key": "BETKPFHWGGDIEWIIYKYQ33LUS4"

--- a/notification-boot/src/main/java/org/dataconservancy/pass/notification/app/config/SpringBootNotificationConfig.java
+++ b/notification-boot/src/main/java/org/dataconservancy/pass/notification/app/config/SpringBootNotificationConfig.java
@@ -209,7 +209,7 @@ public class SpringBootNotificationConfig {
         Mailer mailer = MailerBuilder
                 .withSMTPServerHost(smtpConfig.getHost())
                 .withSMTPServerPort(Integer.parseInt(smtpConfig.getPort()))
-                .withTransportStrategy(TransportStrategy.SMTP) // TODO fixme
+                .withTransportStrategy(TransportStrategy.valueOf(smtpConfig.getSmtpTransport().toUpperCase()))
                 .withDebugLogging(mailerDebug)
                 .buildMailer();
 

--- a/notification-boot/src/main/resources/application.properties
+++ b/notification-boot/src/main/resources/application.properties
@@ -32,6 +32,7 @@ pass.notification.smtp.host=${pass.notification.smtp.host:localhost}
 pass.notification.smtp.port=${pass.notification.smtp.port:587}
 pass.notification.smtp.user=
 pass.notification.smtp.pass=
+pass.notification.smtp.transport=${pass.notification.smtp.transport:SMTP}
 pass.notification.mailer.debug=false
 pass.notification.configuration=classpath:/notification.json
 pass.notification.http.agent=pass-notification/x.y.z

--- a/notification-boot/src/test/resources/notification.json
+++ b/notification-boot/src/test/resources/notification.json
@@ -58,7 +58,8 @@
     "host": "${pass.notification.smtp.host}",
     "port": "${pass.notification.smtp.port}",
     "smtpUser": "${pass.notification.smtp.user}",
-    "smtpPassword": "${pass.notification.smtp.pass}"
+    "smtpPassword": "${pass.notification.smtp.pass}",
+    "smtpTransport": "${pass.notification.smtp.transport}"
   },
   "user-token-generator": {
     "key": "BETKPFHWGGDIEWIIYKYQ33LUS4"

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -92,6 +92,7 @@
                                 <argument>--pass.notification.configuration=classpath:/notification.json</argument>
                                 <argument>--pass.notification.smtp.host=${mail.server}</argument>
                                 <argument>--pass.notification.smtp.port=${mail.msp.port}</argument>
+                                <argument>--pass.notification.smtp.transport=SMTP</argument>
                                 <argument>--pass.notification.queue.event.name=event</argument>
                                 <argument>--pass.link.usertoken.generator.key=BETKPFHWGGDIEWIIYKYQ33LUS4</argument>
                                 <argument>--pass.link.scheme=https</argument>

--- a/notification-integration/src/main/resources/notification.json
+++ b/notification-integration/src/main/resources/notification.json
@@ -63,7 +63,8 @@
     "host": "${pass.notification.smtp.host}",
     "port": "${pass.notification.smtp.port}",
     "smtpUser": "${pass.notification.smtp.user}",
-    "smtpPassword": "${pass.notification.smtp.pass}"
+    "smtpPassword": "${pass.notification.smtp.pass}",
+    "smtpTransport": "${pass.notification.smtp.transport}"
   },
   "user-token-generator": {
     "key": "${pass.link.usertoken.generator.key}"

--- a/notification-model/src/main/java/org/dataconservancy/pass/notification/model/config/smtp/SmtpServerConfig.java
+++ b/notification-model/src/main/java/org/dataconservancy/pass/notification/model/config/smtp/SmtpServerConfig.java
@@ -26,11 +26,11 @@ public class SmtpServerConfig {
 
     private String port;
 
-    private boolean secure = true;
-
     private String smtpUser;
 
     private String smtpPassword;
+
+    private String smtpTransport;
 
     public String getHost() {
         return host;
@@ -46,14 +46,6 @@ public class SmtpServerConfig {
 
     public void setPort(String port) {
         this.port = port;
-    }
-
-    public boolean isSecure() {
-        return secure;
-    }
-
-    public void setSecure(boolean secure) {
-        this.secure = secure;
     }
 
     public String getSmtpUser() {
@@ -72,6 +64,14 @@ public class SmtpServerConfig {
         this.smtpPassword = smtpPassword;
     }
 
+    public String getSmtpTransport() {
+        return smtpTransport;
+    }
+
+    public void setSmtpTransport(String smtpTransport) {
+        this.smtpTransport = smtpTransport;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -79,12 +79,15 @@ public class SmtpServerConfig {
         if (o == null || getClass() != o.getClass())
             return false;
         SmtpServerConfig that = (SmtpServerConfig) o;
-        return secure == that.secure && Objects.equals(host, that.host) && Objects.equals(port, that.port) && Objects.equals(smtpUser, that.smtpUser) && Objects.equals(smtpPassword, that.smtpPassword);
+        return Objects.equals(host, that.host) &&
+                Objects.equals(port, that.port) &&
+                Objects.equals(smtpUser, that.smtpUser) &&
+                Objects.equals(smtpPassword, that.smtpPassword) &&
+                Objects.equals(smtpTransport, that.smtpTransport);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(host, port, secure, smtpUser, smtpPassword);
+        return Objects.hash(host, port, smtpUser, smtpPassword, smtpTransport);
     }
-
 }

--- a/notification-model/src/test/java/org/dataconservancy/pass/notification/model/config/smtp/SmtpServerConfigTest.java
+++ b/notification-model/src/test/java/org/dataconservancy/pass/notification/model/config/smtp/SmtpServerConfigTest.java
@@ -32,7 +32,8 @@ public class SmtpServerConfigTest extends AbstractJacksonMappingTest {
             "      \"host\": \"smtp.gmail.com\",\n" +
             "      \"port\": \"587\",\n" +
             "      \"smtpUser\": \"foo\",\n" +
-            "      \"smtpPassword\": \"bar\"\n" +
+            "      \"smtpPassword\": \"bar\",\n" +
+            "      \"smtpTransport\": \"SMTP\"\n" +
             "    }";
 
 
@@ -41,9 +42,9 @@ public class SmtpServerConfigTest extends AbstractJacksonMappingTest {
         SmtpServerConfig config = mapper.readValue(SMTP_CONFIG_JSON, SmtpServerConfig.class);
         assertEquals("smtp.gmail.com", config.getHost());
         assertEquals("587", config.getPort());
-        assertTrue(config.isSecure());
         assertEquals("foo", config.getSmtpUser());
         assertEquals("bar", config.getSmtpPassword());
+        assertEquals("SMTP", config.getSmtpTransport());
         assertRoundTrip(config, SmtpServerConfig.class);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,7 @@
                             <es.port>${es.http.port}</es.port>
                             <pass.notification.smtp.host>${mail.server}</pass.notification.smtp.host>
                             <pass.notification.smtp.port>${mail.msp.port}</pass.notification.smtp.port>
+                            <pass.notification.smtp.transport>SMTP</pass.notification.smtp.transport>
                             <http.agent>${http.agent}</http.agent>
 
                             <!-- IMAP properties for ITs -->


### PR DESCRIPTION
Support the selection of the SMTP transport strategy using `pass.notification.smtp.transport`, with valid values being: `SMTP`, `SMTPS`, or `SMTP_TLS`.

Note: `SMTP` will use opportunistic TLS, which basically means if the SMTP server advertises `STARTTLS`, TLS will be used.  However, in this mode no verification of server SSL certificates are performed, which allow for trivial attacks against the transport layer to succeed.

`SMTPS` and `SMTP_TLS` will strictly validate server certificates.

I recommend using `SMTP_TLS`.  If the JVM certificate key store does not trust the signers, then the fallback is to use `SMTP` until the JVM can be properly configured.

Closes #46.