### PR TITLE
Fix encoding of links in notification emails

### DIFF
--- a/notification-boot/src/main/java/org/dataconservancy/pass/notification/app/config/SpringBootNotificationConfig.java
+++ b/notification-boot/src/main/java/org/dataconservancy/pass/notification/app/config/SpringBootNotificationConfig.java
@@ -17,6 +17,7 @@ package org.dataconservancy.pass.notification.app.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.helper.ConditionalHelpers;
 import org.dataconservancy.pass.client.PassClient;
@@ -199,7 +200,7 @@ public class SpringBootNotificationConfig {
     public Handlebars handlebars() {
         Handlebars handlebars = new Handlebars();
         handlebars.registerHelper("eq", ConditionalHelpers.eq);
-        return handlebars;
+        return handlebars.with(EscapingStrategy.NOOP);
     }
 
     @Bean


### PR DESCRIPTION
Updates Handlebars to not perform any character encoding or mapping when outputting values.

Consequently, any information provided to Handlebars (e.g. via the parameters map) must be encoded prior.  Alternately, if more flexibility is desired, a helper can be written to perform encoding as needed within the Handlebars template itself.

Resolves https://github.com/OA-PASS/notification-services/issues/52