### PR TITLE
Move whitelist processing to email dispatch

### DIFF
--- a/dispatch-impl/src/main/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailComposer.java
+++ b/dispatch-impl/src/main/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailComposer.java
@@ -16,6 +16,7 @@
 package org.dataconservancy.pass.notification.dispatch.impl.email;
 
 import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.model.User;
 import org.dataconservancy.pass.notification.dispatch.DispatchException;
 import org.dataconservancy.pass.notification.model.Notification;
 import org.dataconservancy.pass.notification.model.config.template.NotificationTemplate;
@@ -27,10 +28,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.net.URI;
+import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.dataconservancy.pass.notification.dispatch.impl.email.RecipientParser.parseRecipientUris;
+import static java.lang.String.join;
 
 /**
  * @author Elliot Metsger (emetsger@jhu.edu)
@@ -41,28 +46,59 @@ public class EmailComposer {
 
     private PassClient passClient;
 
+    private Function<Collection<String>, Collection<String>> whitelist;
+
     @Autowired
-    public EmailComposer(PassClient passClient) {
+    public EmailComposer(PassClient passClient, Function<Collection<String>, Collection<String>> whitelist) {
         this.passClient = passClient;
+        this.whitelist = whitelist;
     }
 
     Email compose(Notification n, Map<NotificationTemplate.Name, String> templates) {
-        String emailToAddress = String.join(",", parseRecipientUris(n.getRecipients()
-                .stream().map(URI::create).collect(Collectors.toSet()), passClient));
-
         if (n.getSender() == null || n.getSender().trim().length() == 0) {
             throw new DispatchException("Notification must not have a null or empty sender!", n);
         }
+
+        // Resolve the Notification Recipient URIs to email addresses, then apply the whitelist of email addresses
+
+        Set<URI> recipientUris = n.getRecipients()
+                .stream().map(URI::create).collect(Collectors.toSet());
+
+
+        LOG.debug("Initial recipients: [{}]", join(",", recipientUris.stream().map(URI::toString).collect(Collectors.toSet())));
+
+        Collection<String> resolvedRecipients = recipientUris
+                .stream()
+                .map(uri -> {
+                    if (uri.getScheme() != null && uri.getScheme().startsWith("http")) {
+                        User user = passClient.readResource(uri, User.class);
+                        return user.getEmail();
+                    }
+
+                    return uri.getSchemeSpecificPart();
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        LOG.debug("Applying whitelist to resolved recipients: [{}]", join(",", resolvedRecipients));
+
+        Collection<String> whitelistedRecipients = whitelist.apply(resolvedRecipients);
+
+        LOG.info("Whitelisted recipients: [{}]", join(", ", whitelistedRecipients));
+
+        String emailToAddress = join(",", whitelistedRecipients);
 
         if (emailToAddress == null || emailToAddress.trim().length() == 0) {
             throw new DispatchException("Notification must not have a null or empty to address!", n);
         }
 
+        // Build the email
+
         EmailPopulatingBuilder builder = EmailBuilder.startingBlank()
                 .from(n.getSender())
                 .to(emailToAddress)
                 .withSubject(templates.getOrDefault(NotificationTemplate.Name.SUBJECT, ""))
-                .withPlainText(String.join("\n\n",
+                .withPlainText(join("\n\n",
                         templates.getOrDefault(NotificationTemplate.Name.BODY, ""),
                         templates.getOrDefault(NotificationTemplate.Name.FOOTER, "")));
 
@@ -82,4 +118,7 @@ public class EmailComposer {
         return builder.buildEmail();
     }
 
+    void setWhitelist(Function<Collection<String>, Collection<String>> whitelist) {
+        this.whitelist = whitelist;
+    }
 }

--- a/dispatch-impl/src/main/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailComposer.java
+++ b/dispatch-impl/src/main/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailComposer.java
@@ -44,6 +44,8 @@ public class EmailComposer {
 
     private static final Logger LOG = LoggerFactory.getLogger(EmailComposer.class);
 
+    private static final Logger NOTIFICATION_LOG = LoggerFactory.getLogger("NOTIFICATION_LOG");
+
     private PassClient passClient;
 
     private Function<Collection<String>, Collection<String>> whitelist;
@@ -84,7 +86,8 @@ public class EmailComposer {
 
         Collection<String> whitelistedRecipients = whitelist.apply(resolvedRecipients);
 
-        LOG.info("Whitelisted recipients: [{}]", join(", ", whitelistedRecipients));
+        LOG.debug("Whitelisted recipients: [{}]", join(", ", whitelistedRecipients));
+        NOTIFICATION_LOG.info("Whitelisted recipients: [{}]", join(", ", whitelistedRecipients));
 
         String emailToAddress = join(",", whitelistedRecipients);
 

--- a/dispatch-impl/src/main/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImpl.java
+++ b/dispatch-impl/src/main/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImpl.java
@@ -31,10 +31,20 @@ import java.util.Map;
  * Dispatches {@link Notification}s as email messages.  Email templates are configured by {@link NotificationTemplate}s
  * obtained from the {@link NotificationConfig}, and processed using a {@link TemplateParameterizer}.
  * <p>
- * This implementation expects notification recipients to be encoded as URIs.  Email addresses can be encoded
- * as {@code mailto} URIs, and PASS {@code User} resources encoded as Fedora repository URIs.  {@code mailto}
- * URIs will be parsed for an email address and optionally a name enclosed with &lt; and &gt;.  PASS {@code User} URIs
- * will be de-referenced and the {@code "email"} property used as the recipient email address.
+ * Notification recipients are expected to be encoded as URIs.  Email addresses can be encoded as {@code mailto} URIs,
+ * and PASS {@code User} resources encoded as Fedora repository URIs.  {@code mailto} URIs will be parsed for an email
+ * address and optionally a name enclosed with &lt; and &gt;.  PASS {@code User} URIs will be de-referenced and the
+ * {@code "email"} property used as the recipient email address.
+ * </p>
+ * <p>
+ * After recipient URIs are resolved to email addresses, the whitelist of email addresses is applied.  If no whitelist
+ * is present, or if the whitelist is empty, all recipients are whitelisted.  If the whitelist is not empty, the
+ * recipients of the notification are filtered, and only the whitelisted addresses will receive an email.
+ * </p>
+ * <p>
+ * If a notification addresses multiple recipients in the {@code TO} field of a {@code Notification}, this
+ * implementation does <em>not</em> send individual emails to each recipient.  It will send a single email, with both
+ * recipients listed in the {@code TO} field of the email.
  * </p>
  *
  * @author Elliot Metsger (emetsger@jhu.edu)
@@ -80,7 +90,17 @@ public class EmailDispatchImpl implements DispatchService {
         } catch (Exception e) {
             throw new DispatchException(e.getMessage(), e, notification);
         }
-
     }
 
+    Parameterizer getParameterizer() {
+        return parameterizer;
+    }
+
+    Mailer getMailer() {
+        return mailer;
+    }
+
+    EmailComposer getComposer() {
+        return composer;
+    }
 }

--- a/dispatch-impl/src/main/java/org/dataconservancy/pass/notification/dispatch/impl/email/SimpleWhitelist.java
+++ b/dispatch-impl/src/main/java/org/dataconservancy/pass/notification/dispatch/impl/email/SimpleWhitelist.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.dataconservancy.pass.notification.impl;
+package org.dataconservancy.pass.notification.dispatch.impl.email;
 
 import org.dataconservancy.pass.notification.model.config.RecipientConfig;
 import org.slf4j.Logger;

--- a/dispatch-impl/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplTest.java
+++ b/dispatch-impl/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplTest.java
@@ -33,8 +33,10 @@ import org.simplejavamail.mailer.Mailer;
 import javax.mail.Message.RecipientType;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -86,6 +88,7 @@ public class EmailDispatchImplTest {
 
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
         notification = mock(Notification.class);
         config = mock(NotificationConfig.class);
@@ -109,7 +112,11 @@ public class EmailDispatchImplTest {
         when(passClient.readResource(URI.create(userUri), User.class)).thenReturn(user);
 
         Parameterizer parameterizer = new Parameterizer(config, templateResolver, templateParameterizer);
-        EmailComposer composer = new EmailComposer(passClient);
+
+        // mock a whitelist that accepts all recipients by simply returning the collection of recipients it was provided
+        Function<Collection<String>, Collection<String>> whitelist = mock(Function.class);
+        when(whitelist.apply(any())).thenAnswer(inv -> inv.getArgument(0));
+        EmailComposer composer = new EmailComposer(passClient, whitelist);
 
         underTest = new EmailDispatchImpl(parameterizer, mailer, composer);
     }

--- a/dispatch-impl/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/SimpleWhitelistTest.java
+++ b/dispatch-impl/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/SimpleWhitelistTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.dataconservancy.pass.notification.impl;
+package org.dataconservancy.pass.notification.dispatch.impl.email;
 
 import org.dataconservancy.pass.notification.model.config.RecipientConfig;
 import org.junit.Before;

--- a/notification-boot/src/main/java/org/dataconservancy/pass/notification/app/config/SpringBootNotificationConfig.java
+++ b/notification-boot/src/main/java/org/dataconservancy/pass/notification/app/config/SpringBootNotificationConfig.java
@@ -36,7 +36,7 @@ import org.dataconservancy.pass.notification.impl.Composer;
 import org.dataconservancy.pass.notification.impl.DefaultNotificationService;
 import org.dataconservancy.pass.notification.impl.LinkValidator;
 import org.dataconservancy.pass.notification.impl.RecipientAnalyzer;
-import org.dataconservancy.pass.notification.impl.SimpleWhitelist;
+import org.dataconservancy.pass.notification.dispatch.impl.email.SimpleWhitelist;
 import org.dataconservancy.pass.notification.impl.SubmissionLinkAnalyzer;
 import org.dataconservancy.pass.notification.impl.UserTokenGenerator;
 import org.dataconservancy.pass.notification.model.config.Mode;
@@ -157,8 +157,8 @@ public class SpringBootNotificationConfig {
     }
 
     @Bean
-    public EmailComposer emailComposer(PassClient passClient) {
-        return new EmailComposer(passClient);
+    public EmailComposer emailComposer(PassClient passClient, SimpleWhitelist whitelist) {
+        return new EmailComposer(passClient, whitelist);
     }
 
     @Bean
@@ -229,7 +229,7 @@ public class SpringBootNotificationConfig {
 
     @Bean
     public RecipientAnalyzer recipientAnalyzer(Function<Collection<String>, Collection<String>> simpleWhitelist) {
-        return new RecipientAnalyzer(simpleWhitelist);
+        return new RecipientAnalyzer();
     }
    
     @Bean

--- a/notification-boot/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactory.java
+++ b/notification-boot/src/test/java/org/dataconservancy/pass/notification/SimpleImapClientFactory.java
@@ -35,8 +35,6 @@ public class SimpleImapClientFactory implements FactoryBean<SimpleImapClient> {
 
     private static final Logger LOG = LoggerFactory.getLogger(SimpleImapClientFactory.class);
 
-    private IMAPStore imapStore;
-
     private Session session;
 
     @Value("${mail.imap.host}")
@@ -49,8 +47,7 @@ public class SimpleImapClientFactory implements FactoryBean<SimpleImapClient> {
     private String imapPass;
 
     @Autowired
-    public SimpleImapClientFactory(IMAPStore imapStore, Session session) {
-        this.imapStore = imapStore;
+    public SimpleImapClientFactory(Session session) {
         this.session = session;
     }
 
@@ -72,6 +69,8 @@ public class SimpleImapClientFactory implements FactoryBean<SimpleImapClient> {
 
     @Override
     public SimpleImapClient getObject() throws Exception {
+        IMAPStore imapStore = imapStore(session);
+
         if (!imapStore.isConnected()) {
             try {
                 LOG.trace("Connecting to IMAP host '{}' store '{}@{}' with username '{}'",
@@ -94,5 +93,13 @@ public class SimpleImapClientFactory implements FactoryBean<SimpleImapClient> {
     @Override
     public Class<?> getObjectType() {
         return SimpleImapClient.class;
+    }
+
+    private IMAPStore imapStore(Session session) {
+        try {
+            return (IMAPStore) session.getStore("imap");
+        } catch (MessagingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/notification-boot/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
+++ b/notification-boot/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
@@ -29,7 +29,9 @@ import org.dataconservancy.pass.notification.impl.ComposerIT;
 import org.dataconservancy.pass.notification.model.Link;
 import org.dataconservancy.pass.notification.model.Notification;
 import org.dataconservancy.pass.notification.model.SimpleNotification;
+import org.dataconservancy.pass.notification.model.config.Mode;
 import org.dataconservancy.pass.notification.model.config.NotificationConfig;
+import org.dataconservancy.pass.notification.model.config.RecipientConfig;
 import org.dataconservancy.pass.notification.model.config.template.NotificationTemplate;
 import org.dataconservancy.pass.notification.util.async.Condition;
 import org.dataconservancy.pass.notification.util.mail.SimpleImapClient;
@@ -46,11 +48,17 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import javax.mail.Message;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.stream.Collectors;
 
 import static java.nio.charset.Charset.forName;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.apache.commons.io.IOUtils.resourceToString;
 import static org.dataconservancy.pass.notification.impl.Links.serialized;
 import static org.dataconservancy.pass.notification.model.Link.Rels.SUBMISSION_REVIEW_INVITE;
@@ -63,9 +71,11 @@ import static org.dataconservancy.pass.notification.model.Notification.Type.SUBM
 import static org.dataconservancy.pass.notification.util.PathUtil.packageAsPath;
 import static org.dataconservancy.pass.notification.util.mail.SimpleImapClient.getBodyAsText;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Elliot Metsger (emetsger@jhu.edu)
@@ -81,6 +91,8 @@ public class EmailDispatchImplIT {
     private static final String RECIPIENT = "staffWithNoGrants@jhu.edu";
 
     private static final String CC = "facultyWithGrants@jhu.edu";
+
+    private static final String GLOBAL_DEMO_CC_ADDRESS = "notification-demo-cc@jhu.edu";
 
     @Autowired
     private EmailDispatchImpl underTest;
@@ -116,8 +128,8 @@ public class EmailDispatchImplIT {
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
         n.setSender(SENDER);
-        n.setCc(Collections.singleton(CC));
-        n.setRecipient(Collections.singleton("mailto:" + RECIPIENT));
+        n.setCc(singleton(CC));
+        n.setRecipient(singleton("mailto:" + RECIPIENT));
 
         String messageId = underTest.dispatch(n);
         assertNotNull(messageId);
@@ -145,7 +157,7 @@ public class EmailDispatchImplIT {
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
         n.setSender(SENDER);
-        n.setRecipient(Collections.singleton(recipientUri.toString()));
+        n.setRecipient(singleton(recipientUri.toString()));
 
         String messageId = underTest.dispatch(n);
 
@@ -178,12 +190,12 @@ public class EmailDispatchImplIT {
             }
         });
 
-        config.setTemplates(Collections.singleton(template));
+        config.setTemplates(singleton(template));
 
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
         n.setSender(SENDER);
-        n.setRecipient(Collections.singleton("mailto:" + RECIPIENT));
+        n.setRecipient(singleton("mailto:" + RECIPIENT));
 
         String messageId = underTest.dispatch(n);
         assertNotNull(messageId);
@@ -225,14 +237,14 @@ public class EmailDispatchImplIT {
             }
         });
 
-        config.setTemplates(Collections.singleton(template));
+        config.setTemplates(singleton(template));
         
         Link link = new Link(URI.create("http://example.org/email/dispatch/myLink"), SUBMISSION_REVIEW_INVITE);
 
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
         n.setSender(SENDER);
-        n.setRecipient(Collections.singleton("mailto:" + RECIPIENT));
+        n.setRecipient(singleton("mailto:" + RECIPIENT));
         n.setParameters(new HashMap<Notification.Param, String>() {
             {
                 put(RESOURCE_METADATA, Composer.resourceMetadata(submission, objectMapper));
@@ -273,7 +285,7 @@ public class EmailDispatchImplIT {
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
         n.setSender(SENDER);
-        n.setRecipient(Collections.singleton("mailto:" + nonExistentRecipientAddress));
+        n.setRecipient(singleton("mailto:" + nonExistentRecipientAddress));
 
         try {
             underTest.dispatch(n);
@@ -298,4 +310,145 @@ public class EmailDispatchImplIT {
         fail("Expected a DispatchException to be thrown.");
     }
 
+    /**
+     * When dispatching a Notification with a non-empty whitelist, only those whitelisted recipients should be present
+     * on the email that is sent
+     */
+    @Test
+    public void testWhitelistFilter() throws Exception {
+        String unlistedRecipient = "mailto:facultyWithNoGrants@jhu.edu";
+        SimpleNotification n = new SimpleNotification();
+        n.setType(SUBMISSION_APPROVAL_INVITE);
+        n.setSender(SENDER);
+        n.setCc(singleton(CC));
+        n.setRecipient(Arrays.asList("mailto:" + RECIPIENT, unlistedRecipient));
+
+        assertTrue(recipientConfig(config).getWhitelist().contains(RECIPIENT));
+        assertFalse(recipientConfig(config).getWhitelist().contains(unlistedRecipient));
+
+        String messageId = underTest.dispatch(n);;
+        Condition.newMessageCondition(messageId, imapClient).await();
+        Message message = Condition.getMessage(messageId, imapClient).call();
+        assertNotNull(message);
+
+        // Only the whitelisted recipient should be present
+        assertEquals(1, message.getRecipients(Message.RecipientType.TO).length);
+        assertEquals(RECIPIENT, message.getRecipients(Message.RecipientType.TO)[0].toString());
+    }
+
+    /**
+     * When composing a Notification, the global CC addresses should not be filtered by the whitelist, while the direct
+     * recipients are.
+     */
+    @Test
+    @DirtiesContext
+    public void testGlobalCCUnaffectedByWhitelist() throws Exception {
+        RecipientConfig recipientConfig = recipientConfig(config);
+
+        // Configure the whitelist such that the submitter's address will
+        // *not* be whitelisted
+        String whitelistEmail = RECIPIENT;
+        recipientConfig.setWhitelist(singleton(whitelistEmail));
+        underTest.getComposer().setWhitelist(new SimpleWhitelist(recipientConfig));
+
+        assertTrue(recipientConfig(config).getWhitelist().contains(RECIPIENT));
+        assertFalse(recipientConfig(config).getWhitelist().contains("facultyWithNoGrants@jhu.edu"));
+
+        SimpleNotification n = new SimpleNotification();
+        n.setType(SUBMISSION_APPROVAL_INVITE);
+        n.setSender(SENDER);
+        n.setRecipient(Arrays.asList("mailto:facultyWithNoGrants@jhu.edu", "mailto:" + whitelistEmail));
+        n.setCc(singleton(GLOBAL_DEMO_CC_ADDRESS));
+
+        String messageId = underTest.dispatch(n);
+        Condition.newMessageCondition(messageId, imapClient).await();
+        Message message = Condition.getMessage(messageId, imapClient).call();
+        assertNotNull(message);
+
+        // The recipient list doesn't contain facultyWithNoGrants@jhu.edu because it isn't whitelisted
+        assertEquals(1, message.getRecipients(Message.RecipientType.TO).length);
+        assertEquals(whitelistEmail, message.getRecipients(Message.RecipientType.TO)[0].toString());
+
+        // The cc list does contain the expected address, because the global cc is not filtered through the whitelist at all
+        assertEquals(1, message.getRecipients(Message.RecipientType.CC).length);
+        assertEquals(GLOBAL_DEMO_CC_ADDRESS, message.getRecipients(Message.RecipientType.CC)[0].toString());
+    }
+
+    /**
+     * Insure that the proper whitelist is used for the specified mode
+     */
+    @Test
+    @DirtiesContext
+    public void testRecipientConfigForEachMode() {
+        // make a unique whitelist and recipient config for each possible mode
+        HashMap<Mode, RecipientConfig> rcs = new HashMap<>();
+        Arrays.stream(Mode.values()).forEach(m -> {
+            RecipientConfig rc = new RecipientConfig();
+            rc.setMode(m);
+            rc.setWhitelist(new ArrayList<>(1));
+            rcs.put(m, rc);
+        });
+
+        config.setRecipientConfigs(rcs.values());
+
+        Arrays.stream(Mode.values()).forEach(mode -> {
+            config.setMode(mode);
+            assertEquals(mode, recipientConfig(config).getMode());
+        });
+    }
+
+    /**
+     * When composing a Notification with an empty whitelist, every recipient should be present.
+     */
+    @Test
+    @DirtiesContext
+    public void testEmptyWhitelist() throws Exception {
+        RecipientConfig recipientConfig = recipientConfig(config);
+        recipientConfig.setWhitelist(Collections.emptyList());
+        underTest.getComposer().setWhitelist(new SimpleWhitelist(recipientConfig));
+
+        String secondRecipient = "facultyWithNoGrants@jhu.edu";
+        SimpleNotification n = new SimpleNotification();
+        n.setType(SUBMISSION_APPROVAL_INVITE);
+        n.setSender(SENDER);
+        n.setCc(Arrays.asList(CC, GLOBAL_DEMO_CC_ADDRESS));
+        n.setRecipient(Arrays.asList("mailto:" + RECIPIENT, "mailto:" + secondRecipient));
+
+        String messageId = underTest.dispatch(n);
+
+        Condition.newMessageCondition(messageId, imapClient).await();
+        Message message = Condition.getMessage(messageId, imapClient).call();
+        assertNotNull(message);
+
+        Collection<String> actualRecipients = Arrays.stream(message.getAllRecipients()).map(Object::toString).collect(Collectors.toSet());
+
+        assertTrue(actualRecipients.contains(RECIPIENT));
+        assertTrue(actualRecipients.contains(secondRecipient));
+        assertTrue(actualRecipients.contains(CC));
+        assertTrue(actualRecipients.contains(GLOBAL_DEMO_CC_ADDRESS));
+        assertEquals(4, actualRecipients.size());
+
+        imapClientFactory.setImapUser(secondRecipient);
+        SimpleImapClient facultyClient = imapClientFactory.getObject();
+
+        Condition.newMessageCondition(messageId, facultyClient).await();
+        message = Condition.getMessage(messageId, facultyClient).call();
+        assertNotNull(message);
+
+        actualRecipients = Arrays.stream(message.getAllRecipients()).map(Object::toString).collect(Collectors.toSet());
+
+        assertTrue(actualRecipients.contains(RECIPIENT));
+        assertTrue(actualRecipients.contains(secondRecipient));
+        assertTrue(actualRecipients.contains(CC));
+        assertTrue(actualRecipients.contains(GLOBAL_DEMO_CC_ADDRESS));
+        assertEquals(4, actualRecipients.size());
+    }
+
+    private static RecipientConfig recipientConfig(NotificationConfig config) {
+        return config.getRecipientConfigs()
+                .stream()
+                .filter(rc -> rc.getMode() == config.getMode())
+                .findAny()
+                .orElseThrow(() -> new RuntimeException("Missing RecipientConfig for mode '" + config.getMode() + "'"));
+    }
 }

--- a/notification-boot/src/test/java/org/dataconservancy/pass/notification/util/mail/SimpleImapClient.java
+++ b/notification-boot/src/test/java/org/dataconservancy/pass/notification/util/mail/SimpleImapClient.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
 /**
  * @author Elliot Metsger (emetsger@jhu.edu)
  */
-public class SimpleImapClient {
+public class SimpleImapClient implements AutoCloseable {
 
     final static String TEXT_PLAIN = "text/plain";
 
@@ -93,6 +93,17 @@ public class SimpleImapClient {
                 throw new RuntimeException(e);
             }
         }).findAny().orElseThrow(() -> new RuntimeException("Message '" + messageId + "' not found in any folder."));
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (store.isConnected()) {
+            LOG.trace("Store '{}@{}' is being closed",
+                    store.getClass().getName(),
+                    Integer.toHexString(System.identityHashCode(store)));
+
+            store.close();
+        }
     }
 
     public static String getBodyAsText(Message message) throws IOException, MessagingException {

--- a/notification-boot/src/test/resources/notification.json
+++ b/notification-boot/src/test/resources/notification.json
@@ -5,10 +5,14 @@
       "mode": "DEMO",
       "fromAddress": "demo-pass@mail.local.domain",
       "global_cc": [
-        "demo@mail.local.domain"
+        "notification-demo-cc@jhu.edu"
       ],
       "whitelist": [
-        "mailto:emetsger@mail.local.domain"
+        "emetsger@mail.local.domain",
+        "staffWithNoGrants@jhu.edu",
+        "facultyWithGrants@jhu.edu",
+        "staffWithGrants@jhu.edu",
+        "moo-thru@bar.edu"
       ]
     }
   ],

--- a/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/Composer.java
+++ b/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/Composer.java
@@ -78,7 +78,7 @@ public class Composer implements BiFunction<Submission, SubmissionEvent, Notific
         this.mapper = mapper;
         Objects.requireNonNull(config, "NotificationConfig must not be null.");
         recipientConfig = getRecipientConfig(config);
-        recipientAnalyzer = new RecipientAnalyzer(new SimpleWhitelist(recipientConfig));
+        recipientAnalyzer = new RecipientAnalyzer();
         submissionLinkAnalyzer = new SubmissionLinkAnalyzer(new UserTokenGenerator(config));
         linkValidator = new LinkValidator(config);
     }

--- a/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/RecipientAnalyzer.java
+++ b/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/RecipientAnalyzer.java
@@ -25,10 +25,8 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toSet;
@@ -42,13 +40,6 @@ public class RecipientAnalyzer implements BiFunction<Submission, SubmissionEvent
 
     private static final Logger LOG = LoggerFactory.getLogger(RecipientAnalyzer.class);
 
-    private Function<Collection<String>, Collection<String>> whitelist;
-
-    public RecipientAnalyzer(Function<Collection<String>, Collection<String>> whitelist) {
-        Objects.requireNonNull(whitelist, "Whitelist must not be null!");
-        this.whitelist = whitelist;
-    }
-
     @Override
     public Collection<String> apply(Submission submission, SubmissionEvent event) {
         switch (event.getEventType()) {
@@ -61,14 +52,14 @@ public class RecipientAnalyzer implements BiFunction<Submission, SubmissionEvent
                                 .orElseThrow(() ->
                                         new RuntimeException(
                                                 "Submitter URI and email are null for " + submission.getId())));
-                return whitelist.apply(singleton(submitterUriOrEmail));
+                return singleton(submitterUriOrEmail);
             }
 
             case CHANGES_REQUESTED:
             case SUBMITTED:
             {
                 // to: submission.preparers
-                return whitelist.apply(submission.getPreparers().stream().map(URI::toString).collect(toSet()));
+                return submission.getPreparers().stream().map(URI::toString).collect(toSet());
             }
 
             case CANCELLED: {
@@ -76,10 +67,10 @@ public class RecipientAnalyzer implements BiFunction<Submission, SubmissionEvent
                 Collection<String> recipients;
                 if (submission.getSubmitter().toString().equals(performedBy)) {
                     recipients =
-                            whitelist.apply(submission.getPreparers().stream().map(URI::toString).collect(toSet()));
+                            submission.getPreparers().stream().map(URI::toString).collect(toSet());
                 } else {
                     recipients =
-                            whitelist.apply(singleton(submission.getSubmitter().toString()));
+                            singleton(submission.getSubmitter().toString());
                 }
 
                 return recipients;

--- a/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/ComposerTest.java
+++ b/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/ComposerTest.java
@@ -110,7 +110,7 @@ public class ComposerTest {
         LinkValidator linkValidator = mock(LinkValidator.class);
         when(linkValidator.test(any())).thenReturn(true);
 
-        underTest = new Composer(notificationConfig, new RecipientAnalyzer(whitelister), submissionLinkAnalyzer, linkValidator, mapper);
+        underTest = new Composer(notificationConfig, new RecipientAnalyzer(), submissionLinkAnalyzer, linkValidator, mapper);
     }
 
     /**

--- a/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/RecipientAnalyzerTest.java
+++ b/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/RecipientAnalyzerTest.java
@@ -22,7 +22,6 @@ import org.dataconservancy.pass.model.Submission;
 import org.dataconservancy.pass.model.SubmissionEvent;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -30,7 +29,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Function;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
@@ -39,7 +37,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -58,22 +55,16 @@ public class RecipientAnalyzerTest {
 
     private SubmissionEvent event;
 
-    private Function<Collection<String>, Collection<String>> whitelist;
-
     private RecipientAnalyzer underTest;
 
     @Before
     @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
-        // Mock a whitelist that will accept any recipient provided to it
-        whitelist = mock(Function.class);
-        when(whitelist.apply(any())).thenAnswer(inv -> inv.getArgument(0));
-
         submission = mock(Submission.class);
 
         event = mock(SubmissionEvent.class);
 
-        underTest = new RecipientAnalyzer(whitelist);
+        underTest = new RecipientAnalyzer();
 
         preparers = Arrays.asList(preparer1, preparer2);
 
@@ -194,6 +185,5 @@ public class RecipientAnalyzerTest {
         expectedRecipients.forEach(expectedRecipient -> assertTrue(actualRecipients.contains(expectedRecipient)));
 
         verify(event, atLeastOnce()).getEventType();
-        verify(whitelist).apply(any());
     }
 }

--- a/notification-integration/src/main/resources/notification.json
+++ b/notification-integration/src/main/resources/notification.json
@@ -8,8 +8,8 @@
         "${pass.notification.demo.global.cc.address}"
       ],
       "whitelist": [
-        "mailto:staffWithGrants@jhu.edu",
-        "mailto:staffWithNoGrants@jhu.edu"
+        "staffWithGrants@jhu.edu",
+        "staffWithNoGrants@jhu.edu"
       ]
     },
     {


### PR DESCRIPTION
### About

Move whitelist application from business logic - i.e. the composition of the Notification - to email dispatch.

The primary affect of this is that whitelists specified in `notification.json` should be specified using **bare** email addresses, _not_ `mailto:` URIs or Fedora resource URIs.  Full whitelist processing is logged at `DEBUG` level.  Whitelist application is logged at `INFO` level.

Unit and integration tests that were performed against the business logic layer (e.g. in `ComposerIT`) were moved and adapted to be performed in the dispatch layer.

### Discussion

Notification business logic attempts to be agnostic with regard to the underlying dispatch and transport of notifications.  Initially the whitelist was applied on the business logic side, which means that it ought only operate on URIs.  This is inconvenient and opaque when a human is configuring a whitelist for User resources in Fedora.  The whitelist would have to reference Fedora URIs rather than simple email addresses or mailto URIs, making it difficult as a human to 1) compose a whitelist, and 2) interpret a whitelist and see which actual email address are whitelisted.

If whitelist processing were to remain on the business logic side, but be updated to operate on bare email addresses, that would be a nod to the underlying dispatch and transport of notifications as emails (i.e. the abstraction provided by the Dispatch API leaks).  Another option would have whitelist processing remain on the BL side, but be updated to resolve URIs to email addresses, and apply the whitelist.  But again, that breaks the abstraction if another form of notification transport were to be added (e.g. SMS or flashes in the view layer).

Therefore, this commit moves whitelist processing to the dispatch side of the house.  Instead of whitelist processing occurring in the Composer on BL side, it now occurs in the EmailDispatchImpl EmailComposer.  Whitelists are composed of bare email addresses and not opaque URIs.  If multiple dispatch transports are added later, the model (and format) of notification services configuration will need to be updated so each dispatch implementation can process its own form of whitelist, if recipient filtering is desired for these new implmentations.

There are some consequences of this move.  The logging aspect which operates at the Dispatch API join point is unaware of whitelist processing.  So when it logs the successful or failed delivery of a Notification, the recipients listed on the Notification may have been filtered inside the dispatch implementation.  This PR addresses this by logging the application of the whitelist at INFO level.  DEBUG level reveals more information about whitelist processing.

Finally, there is a dichotomy in the current BL/Dispatch impl split which has been there from the beginning, which is the "global cc" configuration field.  It is a bare email address, not a mailto address, and that should be addressed to be consistent with the whitelist processing (e.g. the "global cc" should either be updated to carry URIs, or processing of the "global cc" should be moved to the dispatch side of the house).

Addresses #55.