### PR TITLE
Ensure the SMTP username is not a zero-length string.

### DIFF
--- a/notification-boot/src/main/java/org/dataconservancy/pass/notification/app/config/SpringBootNotificationConfig.java
+++ b/notification-boot/src/main/java/org/dataconservancy/pass/notification/app/config/SpringBootNotificationConfig.java
@@ -214,7 +214,7 @@ public class SpringBootNotificationConfig {
                 .withDebugLogging(mailerDebug);
 
 
-        if (smtpConfig.getSmtpUser() != null) {
+        if (smtpConfig.getSmtpUser() != null && smtpConfig.getSmtpUser().trim().length() > 0) {
             builder = builder.withSMTPServerUsername(smtpConfig.getSmtpUser())
                     .withSMTPServerPassword(smtpConfig.getSmtpPassword());
         }


### PR DESCRIPTION
Use the username and password supplied by the SMTP config when building the Mailer in order to successfully perform SMTP auth.