### PR TITLE
Implement more robust ITs using SMTP message headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,11 @@ before_install:
 
 install: mvn -U install -Dspring-boot.stop.skip -Dspring-boot.run.skip -Ddocker.skip=true -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
-script: mvn clean verify -DtrimStackTrace=false
+script: mvn clean verify -DtrimStackTrace=false -Ddocker.useColor=false
 
 jdk:
 - oraclejdk8
 
-#bump
+after_failure:
+  - docker logs `docker ps -a|grep mailserver |awk '{print $1}'`
+  - docker logs `docker ps -a|grep ldap |awk '{print $1}'`

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -63,6 +63,8 @@
                         <configuration>
                             <useTestClasspath>false</useTestClasspath>
                             <mainClass>org.dataconservancy.pass.notification.NotificationApp</mainClass>
+                            <!-- Adjust this value to see more or less debugging when running ITs -->
+                            <jvmArguments>-Dorg.dataconservancy.pass.notification.level=INFO</jvmArguments>
                             <arguments>
                                 <argument>--pass.fedora.user=${pass.fedora.user}</argument>
                                 <argument>--pass.fedora.password=${pass.fedora.password}</argument>

--- a/notification-integration/src/main/resources/templates/approval-invite-body.hbr
+++ b/notification-integration/src/main/resources/templates/approval-invite-body.hbr
@@ -1,1 +1,5 @@
-Approval Invite Body
+Hello,
+
+A submission titled "{{#resource_metadata}}{{title}}{{/resource_metadata}}" been prepared on your behalf{{#event_metadata}}{{#if comment}} with comment "{{comment}}"{{else}}.{{/if}}{{/event_metadata}}
+
+Please review the submission at the following URL: {{#each link_metadata}}{{#eq rel "submission-review-invite"}}{{href}}{{else}}{{/eq}}{{/each}}

--- a/notification-integration/src/main/resources/templates/approval-invite-subject.hbr
+++ b/notification-integration/src/main/resources/templates/approval-invite-subject.hbr
@@ -1,1 +1,1 @@
-Approval Invite Subject
+PASS Submission titled "{{#resource_metadata}}{{title}}{{/resource_metadata}}" awaiting your approval

--- a/notification-integration/src/main/resources/templates/approval-requested-body.hbr
+++ b/notification-integration/src/main/resources/templates/approval-requested-body.hbr
@@ -1,1 +1,5 @@
-Approval Requested Body
+Hello,
+
+A submission titled "{{#resource_metadata}}{{title}}{{/resource_metadata}}" been prepared on your behalf{{#event_metadata}}{{#if comment}} with comment "{{comment}}"{{else}}.{{/if}}{{/event_metadata}}
+
+Please review the submission at the following URL: {{#each link_metadata}}{{#eq rel "submission-review"}}{{href}}{{else}}{{/eq}}{{/each}}

--- a/notification-integration/src/main/resources/templates/approval-requested-subject.hbr
+++ b/notification-integration/src/main/resources/templates/approval-requested-subject.hbr
@@ -1,1 +1,1 @@
-Approval Requested Subject
+PASS Submission titled "{{#resource_metadata}}{{title}}{{/resource_metadata}}" awaiting your approval

--- a/notification-integration/src/main/resources/templates/changes-requested-body.hbr
+++ b/notification-integration/src/main/resources/templates/changes-requested-body.hbr
@@ -1,1 +1,5 @@
-Changes Requested Body
+Hello,
+
+A submission you prepared titled "{{#resource_metadata}}{{title}}{{/resource_metadata}}" requires changes{{#event_metadata}}{{#if comment}}: "{{comment}}"{{else}}.{{/if}}{{/event_metadata}}
+
+Please review the submission at the following URL and make any necessary changes {{#each link_metadata}}{{#eq rel "submission-review"}}{{href}}{{else}}{{/eq}}{{/each}}

--- a/notification-integration/src/main/resources/templates/changes-requested-subject.hbr
+++ b/notification-integration/src/main/resources/templates/changes-requested-subject.hbr
@@ -1,1 +1,1 @@
-Changes Requested Subject
+PASS Submission titled "{{#resource_metadata}}{{title}}{{/resource_metadata}}" requires updating

--- a/notification-integration/src/main/resources/templates/footer.hbr
+++ b/notification-integration/src/main/resources/templates/footer.hbr
@@ -1,1 +1,4 @@
-Footer
+---
+Public Access Submission System
+Johns Hopkins University
+https://pass.jhu.eduFooter

--- a/notification-integration/src/main/resources/templates/submission-cancelled-body.hbr
+++ b/notification-integration/src/main/resources/templates/submission-cancelled-body.hbr
@@ -1,1 +1,5 @@
-Submission Cancelled Body
+Hello,
+
+The submission titled "{{#resource_metadata}}{{title}}{{/resource_metadata}}" has been cancelled{{#event_metadata}}{{#if comment}}: "{{comment}}"{{else}}.{{/if}}{{/event_metadata}}
+
+For reference, the cancelled submission may be viewed at {{#each link_metadata}}{{#eq rel "submission-view"}}{{href}}{{else}}{{/eq}}{{/each}}

--- a/notification-integration/src/main/resources/templates/submission-cancelled-subject.hbr
+++ b/notification-integration/src/main/resources/templates/submission-cancelled-subject.hbr
@@ -1,1 +1,1 @@
-Submission Cancelled Subject
+PASS Submission cancelled: "{{#resource_metadata}}{{title}}{{/resource_metadata}}"

--- a/notification-integration/src/main/resources/templates/submission-submitted-body.hbr
+++ b/notification-integration/src/main/resources/templates/submission-submitted-body.hbr
@@ -1,1 +1,5 @@
-Submission Submitted Body
+Hello,
+
+The submission titled "{{#resource_metadata}}{{title}}{{/resource_metadata}}" was successfully submitted{{#event_metadata}}{{#if comment}}: "{{comment}}"{{else}}!{{/if}}{{/event_metadata}}
+
+For reference, the completed submission may be viewed at {{#each link_metadata}}{{#eq rel "submission-view"}}{{href}}{{else}}{{/eq}}{{/each}}

--- a/notification-integration/src/main/resources/templates/submission-submitted-subject.hbr
+++ b/notification-integration/src/main/resources/templates/submission-submitted-subject.hbr
@@ -1,1 +1,1 @@
-Submission Submitted Subject
+PASS Submission was submitted: "{{#resource_metadata}}{{title}}{{/resource_metadata}}"

--- a/notification-integration/src/test/java/org/dataconservancy/pass/notification/MailUtil.java
+++ b/notification-integration/src/test/java/org/dataconservancy/pass/notification/MailUtil.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2020 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.notification;
+
+import javax.mail.Session;
+import java.util.Properties;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
+import static java.lang.System.getProperty;
+import static java.lang.System.getenv;
+
+/**
+ * Utility class to support and encapsulate the creation of Java messaging objects.  It is meant to be used when
+ * Spring injection is not available, as is the case in the notification-integration module (the module treats
+ * notification services as a black box).
+ *
+ * The configuration of the javax.mail.Session is done using environment variables (preferred) and system properties.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class MailUtil {
+
+    /**
+     * Configured using MAIL_IMAP_USER or mail.imap.user.
+     */
+    private String imapUser = getenv().getOrDefault("MAIL_IMAP_USER",
+            getProperty("mail.imap.user", "staffwithnogrants@jhu.edu"));
+
+    /**
+     * Configured using MAIL_IMAP_PASSWORD or mail.imap.password.
+     */
+    private String imapPass = getenv().getOrDefault("MAIL_IMAP_PASSWORD",
+            getProperty("mail.imap.password", "moo"));
+
+    /**
+     * Configured using MAIL_IMAP_HOST or mail.imap.host.
+     */
+    private String imapHost = getenv().getOrDefault("MAIL_IMAP_HOST",
+            getProperty("mail.imap.host", "localhost"));
+
+    /**
+     * Configured using MAIL_IMAP_PORT or mail.imap.port.
+     */
+    private String imapPort = getenv().getOrDefault("MAIL_IMAP_PORT",
+            getProperty("mail.imap.port", "143"));
+
+    /**
+     * Configured using MAIL_IMAP_SSL_ENABLE or mail.imap.ssl.enable.
+     */
+    private boolean useSsl = parseBoolean(getenv().getOrDefault("MAIL_IMAP_SSL_ENABLE",
+            getProperty("mail.imap.ssl.enable", "true")));
+
+    /**
+     * Configured using MAIL_IMAP_SSL_TRUST or mail.imap.ssl.trust.
+     */
+    private String sslTrust = getenv().getOrDefault("MAIL_IMAP_SSL_TRUST",
+            getProperty("mail.imap.ssl.trust", "*"));
+
+    /**
+     * Configured using MAIL_IMAP_STARTTLS_ENABLE or mail.imap.starttls.enable.
+     */
+    private boolean enableTlsIfSupported = parseBoolean(getenv().getOrDefault("MAIL_IMAP_STARTTLS_ENABLE",
+            getProperty("mail.imap.starttls.enable", "true")));
+
+    /**
+     * Configured using MAIL_IMAP_FINALIZECLEANCLOSE or mail.imap.finalizecleanclose.
+     */
+    private boolean closeOnFinalize = parseBoolean(getenv().getOrDefault("MAIL_IMAP_FINALIZECLEANCLOSE",
+            getProperty("mail.imap.finalizecleanclose", "true")));
+
+    /**
+     * Configured using MAIL_IMAP_CONNECTIONTIMEOUT or mail.imap.connectiontimeout.
+     */
+    private int connectTimeout = parseInt(getenv().getOrDefault("MAIL_IMAP_CONNECTIONTIMEOUT",
+            getProperty("mail.imap.connectiontimeout", "60")));
+
+    /**
+     * Configured using MAIL_IMAP_TIMEOUT or mail.imap.timeout.
+     */
+    private int timeout = parseInt(getenv().getOrDefault("MAIL_IMAP_TIMEOUT",
+            getProperty("mail.imap.timeout", "60")));
+
+    /**
+     * Answers a configured Session based on the state encapsulated by this instance.
+     *
+     * @return a configured Session
+     */
+    Session mailSession() {
+        return Session.getDefaultInstance(new Properties() {
+            {
+                put("mail.imap.host", imapHost);
+                put("mail.imap.port", imapPort);
+                put("mail.imap.ssl.enable", useSsl);
+                put("mail.imap.ssl.trust", sslTrust);
+                put("mail.imap.starttls.enable", enableTlsIfSupported);
+                put("mail.imap.finalizecleanclose", closeOnFinalize);
+                put("mail.imap.connectiontimeout", connectTimeout);
+                put("mail.imap.timeout", timeout);
+            }
+        });
+    }
+
+    String getImapUser() {
+        return imapUser;
+    }
+
+    void setImapUser(String imapUser) {
+        this.imapUser = imapUser;
+    }
+
+    String getImapPass() {
+        return imapPass;
+    }
+
+    void setImapPass(String imapPass) {
+        this.imapPass = imapPass;
+    }
+
+    String getImapHost() {
+        return imapHost;
+    }
+
+    void setImapHost(String imapHost) {
+        this.imapHost = imapHost;
+    }
+
+    String getImapPort() {
+        return imapPort;
+    }
+
+    void setImapPort(String imapPort) {
+        this.imapPort = imapPort;
+    }
+
+    boolean isUseSsl() {
+        return useSsl;
+    }
+
+    void setUseSsl(boolean useSsl) {
+        this.useSsl = useSsl;
+    }
+
+    String getSslTrust() {
+        return sslTrust;
+    }
+
+    void setSslTrust(String sslTrust) {
+        this.sslTrust = sslTrust;
+    }
+
+    boolean isEnableTlsIfSupported() {
+        return enableTlsIfSupported;
+    }
+
+    void setEnableTlsIfSupported(boolean enableTlsIfSupported) {
+        this.enableTlsIfSupported = enableTlsIfSupported;
+    }
+
+    boolean isCloseOnFinalize() {
+        return closeOnFinalize;
+    }
+
+    void setCloseOnFinalize(boolean closeOnFinalize) {
+        this.closeOnFinalize = closeOnFinalize;
+    }
+
+    int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    int getTimeout() {
+        return timeout;
+    }
+
+    void setTimeout(int timeout) {
+        this.timeout = timeout;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -62,10 +62,29 @@
             </activation>
             <properties>
                 <mail.waitms>30000</mail.waitms>
-                <ldap.waitms>15000</ldap.waitms>
-                <mail.imap.connectiontimeout>60000</mail.imap.connectiontimeout>
-                <mail.imap.timeout>60000</mail.imap.timeout>
+                <ldap.waitms>30000</ldap.waitms>
+                <mail.imap.connectiontimeout>120000</mail.imap.connectiontimeout>
+                <mail.imap.timeout>120000</mail.imap.timeout>
             </properties>
+
+            <!-- may be used to debug SSL/TLS on Travis -->
+            <!--build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>mavenfailsafeplugin</artifactId>
+                            <version>${maven.failsafe.plugin.version}</version>
+                            <configuration>
+                                <systemProperties>
+                                    <javax.net.debug>all</javax.net.debug>
+                                </systemProperties>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build-->
+
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,9 @@
                             <pass.notification.smtp.transport>SMTP</pass.notification.smtp.transport>
                             <http.agent>${http.agent}</http.agent>
 
+                            <!-- Used by some ITs -->
+                            <pass.jsonld.context>${pass.jsonld.context}</pass.jsonld.context>
+
                             <!-- IMAP properties for ITs -->
                             <mail.imap.host>${mail.imap.host}</mail.imap.host>
                             <mail.imap.port>${mail.imap.port}</mail.imap.port>


### PR DESCRIPTION
* Updates the EmailComposer to add SMTP message headers containing the Submission URI and Notification type (X-PASS-Submission-ID and X-PASS-Notification-Type respectively)
* Updates IT support classes to enable searching for messages using SMTP headers
* ITs may now use system property pass.jsonld.context when creating resources with a specific model version
* Replaced the email templates with copies from production.  This allows for more robust ITs that check for correctly interpolated values in emails.
* Includes updates for the Travis build environment in the form of increased timeouts and container startup time thresholds
