### PR TITLE
Add support for BCC of notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,28 @@ Each configuration mode (discussed above) may have an associated whitelist.  If 
 
 Production should use an empty whitelist (i.e. all potential notification recipients are whitelisted).
 
-### Global Carbon Copy
+### Global Carbon Copy Support
 
 Each configuration mode (discussed above) may specify one or more "global carbon copy" addresses.  These addresses will receive a copy of each email sent by Notification Services (NS).  Global carbon copy addresses are implicitly whitelisted; they do not need to be explicitly configured in a whitelist.
+
+Blind carbon copy is also supported.
+
+Here is an example recipient configuration that specifies a global carbon copy and a global blind carbon copy:
+
+    "recipient-config": [
+        {
+          "mode": "DEMO",
+          "fromAddress": "pass-noreply@jhu.edu",
+          "global_cc": [
+            "pass-support@jhu.edu"
+          ],
+          "global_bcc": [
+            "pass-ops@jhu.edu"
+          ]          
+        }
+    ]
+    
+Multiple email addresses may be specified.
 
 ### Example
 
@@ -260,7 +279,7 @@ The state of the `Submission` vis-a-vis the `SubmissionEvent` (adapted from the 
 ### Parameters
 
 The `parameters` map carries simple strings or serialized JSON structures.
-- `TO`, `CC`, `BCC` (not used), `FROM`, and `SUBJECT` are all simple strings
+- `TO`, `CC`, `BCC`, `FROM`, and `SUBJECT` are all simple strings
 - `RESOURCE_METADATA`, `EVENT_METADATA`, and `LINKS` all contain serialized JSON structures
 - Handlebars, the Mustache-based template engine, can navigate the JSON structures to pull out the desired information for email templates.
 

--- a/dispatch-api/pom.xml
+++ b/dispatch-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       <groupId>org.dataconservancy.pass.notify</groupId>
       <artifactId>notify-parent</artifactId>
-      <version>0.0.3-3.4-SNAPSHOT</version>
+      <version>0.1.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>dispatch-api</artifactId>

--- a/dispatch-impl/pom.xml
+++ b/dispatch-impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       <groupId>org.dataconservancy.pass.notify</groupId>
       <artifactId>notify-parent</artifactId>
-      <version>0.0.3-3.4-SNAPSHOT</version>
+      <version>0.1.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>dispatch-impl</artifactId>

--- a/logging-aop/pom.xml
+++ b/logging-aop/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       <groupId>org.dataconservancy.pass.notify</groupId>
       <artifactId>notify-parent</artifactId>
-      <version>0.0.3-3.4-SNAPSHOT</version>
+      <version>0.1.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>logging-aop</artifactId>

--- a/logging-aop/src/main/java/org/dataconservancy/pass/notification/aop/logging/LoggingAspect.java
+++ b/logging-aop/src/main/java/org/dataconservancy/pass/notification/aop/logging/LoggingAspect.java
@@ -55,9 +55,10 @@ public class LoggingAspect {
 
         Notification n = (Notification) args[0];
 
-        NOTIFICATION_LOG.debug("Dispatching notification to [{}], cc [{}] (Notification type: {}, Event URI: {}, Resource URI: {})",
+        NOTIFICATION_LOG.debug("Dispatching notification to [{}], cc [{}] bcc [{}] (Notification type: {}, Event URI: {}, Resource URI: {})",
                 join(",", ofNullable(n.getRecipients()).orElseGet(Collections::emptyList)),
                 join(",", ofNullable(n.getCc()).orElseGet(Collections::emptyList)),
+                join(",", ofNullable(n.getBcc()).orElseGet(Collections::emptyList)),
                 n.getType(),
                 n.getEventUri(),
                 n.getResourceUri());
@@ -72,10 +73,11 @@ public class LoggingAspect {
 
         Notification n = (Notification) args[0];
 
-        NOTIFICATION_LOG.info("Successfully dispatched notification with id {} to [{}], cc [{}] (Notification type: {}, Event URI: {}, Resource URI: {})",
+        NOTIFICATION_LOG.info("Successfully dispatched notification with id {} to [{}], cc [{}] bcc [{}] (Notification type: {}, Event URI: {}, Resource URI: {})",
                 id,
                 join(",", ofNullable(n.getRecipients()).orElseGet(Collections::emptyList)),
                 join(",", ofNullable(n.getCc()).orElseGet(Collections::emptyList)),
+                join(",", ofNullable(n.getBcc()).orElseGet(Collections::emptyList)),
                 n.getType(),
                 n.getEventUri(),
                 n.getResourceUri());
@@ -87,9 +89,10 @@ public class LoggingAspect {
         Notification n;
 
         if (ex instanceof DispatchException && (n = ((DispatchException) ex).getNotification()) != null) {
-            NOTIFICATION_LOG.warn("FAILED dispatching notification to [{}], cc [{}] (Notification type: {}, Event URI: {}, Resource URI: {})",
+            NOTIFICATION_LOG.warn("FAILED dispatching notification to [{}], cc [{}] bcc [{}] (Notification type: {}, Event URI: {}, Resource URI: {})",
                     join(",", ofNullable(n.getRecipients()).orElseGet(Collections::emptyList)),
                     join(",", ofNullable(n.getCc()).orElseGet(Collections::emptyList)),
+                    join(",", ofNullable(n.getBcc()).orElseGet(Collections::emptyList)),
                     n.getType(),
                     n.getEventUri(),
                     n.getResourceUri(),

--- a/notification-boot/pom.xml
+++ b/notification-boot/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       <groupId>org.dataconservancy.pass.notify</groupId>
       <artifactId>notify-parent</artifactId>
-      <version>0.0.3-3.4-SNAPSHOT</version>
+      <version>0.1.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>notification-boot</artifactId>

--- a/notification-boot/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
+++ b/notification-boot/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
@@ -140,7 +140,7 @@ public class EmailDispatchImplIT {
         n.setType(SUBMISSION_APPROVAL_INVITE);
         n.setSender(SENDER);
         n.setCc(singleton(CC));
-        n.setRecipient(singleton("mailto:" + RECIPIENT));
+        n.setRecipients(singleton("mailto:" + RECIPIENT));
         n.setResourceUri(SUBMISSION_RESOURCE_URI);
         n.setEventUri(EVENT_RESOURCE_URI);
 
@@ -170,7 +170,7 @@ public class EmailDispatchImplIT {
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
         n.setSender(SENDER);
-        n.setRecipient(singleton(recipientUri.toString()));
+        n.setRecipients(singleton(recipientUri.toString()));
         n.setResourceUri(SUBMISSION_RESOURCE_URI);
         n.setEventUri(EVENT_RESOURCE_URI);
 
@@ -212,7 +212,7 @@ public class EmailDispatchImplIT {
         n.setSender(SENDER);
         n.setResourceUri(SUBMISSION_RESOURCE_URI);
         n.setEventUri(EVENT_RESOURCE_URI);
-        n.setRecipient(singleton("mailto:" + RECIPIENT));
+        n.setRecipients(singleton("mailto:" + RECIPIENT));
 
         String messageId = underTest.dispatch(n);
         assertNotNull(messageId);
@@ -263,7 +263,7 @@ public class EmailDispatchImplIT {
         SimpleNotification n = new SimpleNotification();
         n.setType(SUBMISSION_APPROVAL_INVITE);
         n.setSender(SENDER);
-        n.setRecipient(singleton("mailto:" + RECIPIENT));
+        n.setRecipients(singleton("mailto:" + RECIPIENT));
         n.setEventUri(event.getId());
         n.setResourceUri(submission.getId());
         n.setParameters(new HashMap<Notification.Param, String>() {
@@ -308,7 +308,7 @@ public class EmailDispatchImplIT {
         n.setSender(SENDER);
         n.setResourceUri(SUBMISSION_RESOURCE_URI);
         n.setEventUri(EVENT_RESOURCE_URI);
-        n.setRecipient(singleton("mailto:" + nonExistentRecipientAddress));
+        n.setRecipients(singleton("mailto:" + nonExistentRecipientAddress));
 
         try {
             underTest.dispatch(n);
@@ -346,7 +346,7 @@ public class EmailDispatchImplIT {
         n.setResourceUri(SUBMISSION_RESOURCE_URI);
         n.setEventUri(EVENT_RESOURCE_URI);
         n.setCc(singleton(CC));
-        n.setRecipient(Arrays.asList("mailto:" + RECIPIENT, unlistedRecipient));
+        n.setRecipients(Arrays.asList("mailto:" + RECIPIENT, unlistedRecipient));
 
         assertTrue(recipientConfig(config).getWhitelist().contains(RECIPIENT));
         assertFalse(recipientConfig(config).getWhitelist().contains(unlistedRecipient));
@@ -384,7 +384,7 @@ public class EmailDispatchImplIT {
         n.setSender(SENDER);
         n.setResourceUri(SUBMISSION_RESOURCE_URI);
         n.setEventUri(EVENT_RESOURCE_URI);
-        n.setRecipient(Arrays.asList("mailto:facultyWithNoGrants@jhu.edu", "mailto:" + whitelistEmail));
+        n.setRecipients(Arrays.asList("mailto:facultyWithNoGrants@jhu.edu", "mailto:" + whitelistEmail));
         n.setCc(singleton(GLOBAL_DEMO_CC_ADDRESS));
 
         String messageId = underTest.dispatch(n);
@@ -441,7 +441,7 @@ public class EmailDispatchImplIT {
         n.setResourceUri(SUBMISSION_RESOURCE_URI);
         n.setEventUri(EVENT_RESOURCE_URI);
         n.setCc(Arrays.asList(CC, GLOBAL_DEMO_CC_ADDRESS));
-        n.setRecipient(Arrays.asList("mailto:" + RECIPIENT, "mailto:" + secondRecipient));
+        n.setRecipients(Arrays.asList("mailto:" + RECIPIENT, "mailto:" + secondRecipient));
 
         String messageId = underTest.dispatch(n);
 

--- a/notification-boot/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
+++ b/notification-boot/src/test/java/org/dataconservancy/pass/notification/dispatch/impl/email/EmailDispatchImplIT.java
@@ -179,7 +179,8 @@ public class EmailDispatchImplIT {
         assertNotNull(messageId);
 
         // Original recipient should have the message
-        Message recipientMsg = imapClient.getMessage(messageId);
+        Condition.newGetMessageCondition(messageId, imapClient).await();
+        Message recipientMsg = Condition.getMessage(messageId, imapClient).call();
         assertNotNull(recipientMsg);
         assertEquals("Approval Invite Subject", recipientMsg.getSubject());
         assertEquals(expectedBody, getBodyAsText(recipientMsg));

--- a/notification-boot/src/test/resources/notification.json
+++ b/notification-boot/src/test/resources/notification.json
@@ -7,6 +7,9 @@
       "global_cc": [
         "notification-demo-cc@jhu.edu"
       ],
+      "global_bcc": [
+        "notification-demo-bcc@jhu.edu"
+      ],
       "whitelist": [
         "emetsger@mail.local.domain",
         "staffWithNoGrants@jhu.edu",

--- a/notification-impl/pom.xml
+++ b/notification-impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       <groupId>org.dataconservancy.pass.notify</groupId>
       <artifactId>notify-parent</artifactId>
-      <version>0.0.3-3.4-SNAPSHOT</version>
+      <version>0.1.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>notification-impl</artifactId>

--- a/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/Composer.java
+++ b/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/Composer.java
@@ -123,6 +123,12 @@ public class Composer implements BiFunction<Submission, SubmissionEvent, Notific
             params.put(Notification.Param.CC, join(",", cc));
         }
 
+        Collection<String> bcc = recipientConfig.getGlobalBcc();
+        if (bcc != null && !bcc.isEmpty()) {
+            notification.setBcc(bcc);
+            params.put(Notification.Param.BCC, join(",", bcc));
+        }
+
         notification.setResourceUri(submission.getId());
         params.put(Notification.Param.RESOURCE_METADATA, resourceMetadata(submission, mapper));
 

--- a/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/Composer.java
+++ b/notification-impl/src/main/java/org/dataconservancy/pass/notification/impl/Composer.java
@@ -137,7 +137,7 @@ public class Composer implements BiFunction<Submission, SubmissionEvent, Notific
         params.put(Notification.Param.FROM, from);
 
         Collection<String> recipients = recipientAnalyzer.apply(submission, event);
-        notification.setRecipient(recipients);
+        notification.setRecipients(recipients);
         params.put(Notification.Param.TO, join(",", recipients));
         
         params.put(Notification.Param.LINKS, concat(submissionLinkAnalyzer.apply(submission, event))

--- a/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/ComposerTest.java
+++ b/notification-impl/src/test/java/org/dataconservancy/pass/notification/impl/ComposerTest.java
@@ -68,6 +68,8 @@ public class ComposerTest {
 
     private static final List<String> NOTIFICATION_GLOBAL_CC_ADDRESS = Arrays.asList("pass@jhu.edu", "pass-prod-cc@jhu.edu");
 
+    private static final List<String> NOTIFICATION_GLOBAL_BCC_ADDRESS = singletonList("pass-prod-bcc@jhu.edu");
+
     private Composer underTest;
 
     private Function<Collection<String>, Collection<String>> whitelister;
@@ -92,6 +94,7 @@ public class ComposerTest {
         recipientConfig.setMode(runtimeMode);
         recipientConfig.setFromAddress(NOTIFICATION_FROM_ADDRESS);
         recipientConfig.setGlobalCc(NOTIFICATION_GLOBAL_CC_ADDRESS);
+        recipientConfig.setGlobalBcc(NOTIFICATION_GLOBAL_BCC_ADDRESS);
 
         // all recipients are whitelisted
         when(whitelister.apply(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -144,6 +147,7 @@ public class ComposerTest {
         assertEquals(userUri, params.get(Param.TO));
         assertEquals(NOTIFICATION_FROM_ADDRESS, params.get(Param.FROM));
         assertEquals(String.join(",", NOTIFICATION_GLOBAL_CC_ADDRESS), params.get(Param.CC));
+        assertEquals(String.join(",", NOTIFICATION_GLOBAL_BCC_ADDRESS), params.get(Param.BCC));
         assertEquals(RESOURCE_METADATA, params.get(Param.RESOURCE_METADATA));
         assertEquals(Notification.Type.SUBMISSION_APPROVAL_INVITE, notification.getType());
 
@@ -179,6 +183,7 @@ public class ComposerTest {
         assertEquals(userUri, params.get(Param.TO));
         assertEquals(NOTIFICATION_FROM_ADDRESS, params.get(Param.FROM));
         assertEquals(String.join(",", NOTIFICATION_GLOBAL_CC_ADDRESS), params.get(Param.CC));
+        assertEquals(String.join(",", NOTIFICATION_GLOBAL_BCC_ADDRESS), params.get(Param.BCC));
         assertEquals(RESOURCE_METADATA, params.get(Param.RESOURCE_METADATA));
         assertEquals(Notification.Type.SUBMISSION_APPROVAL_REQUESTED, notification.getType());
 
@@ -213,6 +218,7 @@ public class ComposerTest {
         assertEquals(preparersUri, params.get(Param.TO));
         assertEquals(NOTIFICATION_FROM_ADDRESS, params.get(Param.FROM));
         assertEquals(String.join(",", NOTIFICATION_GLOBAL_CC_ADDRESS), params.get(Param.CC));
+        assertEquals(String.join(",", NOTIFICATION_GLOBAL_BCC_ADDRESS), params.get(Param.BCC));
         assertEquals(RESOURCE_METADATA, params.get(Param.RESOURCE_METADATA));
         assertEquals(Notification.Type.SUBMISSION_CHANGES_REQUESTED, notification.getType());
 
@@ -247,6 +253,7 @@ public class ComposerTest {
         assertEquals(preparersUri, params.get(Param.TO));
         assertEquals(NOTIFICATION_FROM_ADDRESS, params.get(Param.FROM));
         assertEquals(String.join(",", NOTIFICATION_GLOBAL_CC_ADDRESS), params.get(Param.CC));
+        assertEquals(String.join(",", NOTIFICATION_GLOBAL_BCC_ADDRESS), params.get(Param.BCC));
         assertEquals(RESOURCE_METADATA, params.get(Param.RESOURCE_METADATA));
         assertEquals(Notification.Type.SUBMISSION_SUBMISSION_SUBMITTED, notification.getType());
 
@@ -284,6 +291,7 @@ public class ComposerTest {
         assertEquals(submitterUri, params.get(Param.TO));
         assertEquals(NOTIFICATION_FROM_ADDRESS, params.get(Param.FROM));
         assertEquals(String.join(",", NOTIFICATION_GLOBAL_CC_ADDRESS), params.get(Param.CC));
+        assertEquals(String.join(",", NOTIFICATION_GLOBAL_BCC_ADDRESS), params.get(Param.BCC));
         assertEquals(RESOURCE_METADATA, params.get(Param.RESOURCE_METADATA));
         assertEquals(Notification.Type.SUBMISSION_SUBMISSION_CANCELLED, notification.getType());
 
@@ -321,6 +329,7 @@ public class ComposerTest {
         assertEquals(preparersUri, params.get(Param.TO));
         assertEquals(NOTIFICATION_FROM_ADDRESS, params.get(Param.FROM));
         assertEquals(String.join(",", NOTIFICATION_GLOBAL_CC_ADDRESS), params.get(Param.CC));
+        assertEquals(String.join(",", NOTIFICATION_GLOBAL_BCC_ADDRESS), params.get(Param.BCC));
         assertEquals(RESOURCE_METADATA, params.get(Param.RESOURCE_METADATA));
         assertEquals(Notification.Type.SUBMISSION_SUBMISSION_CANCELLED, notification.getType());
 

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       <groupId>org.dataconservancy.pass.notify</groupId>
       <artifactId>notify-parent</artifactId>
-      <version>0.0.3-3.4-SNAPSHOT</version>
+      <version>0.1.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>notification-integration</artifactId>

--- a/notification-integration/pom.xml
+++ b/notification-integration/pom.xml
@@ -73,6 +73,7 @@
                                 <argument>--pass.notification.mode=DEMO</argument>
                                 <argument>--pass.notification.demo.from.address=noreply@pass.jh.edu</argument>
                                 <argument>--pass.notification.demo.global.cc.address=notification-demo-cc@jhu.edu</argument>
+                                <argument>--pass.notification.demo.global.bcc.address=notification-demo-bcc@jhu.edu</argument>
                                 <argument>--pass.notification.production.from.address=noreply@pass.jh.edu</argument>
                                 <argument>--pass.notification.production.global.cc.address=notification-prod-cc@jhu.edu</argument>
                                 <argument>--pass.notification.configuration=classpath:/notification.json</argument>

--- a/notification-integration/src/main/resources/notification.json
+++ b/notification-integration/src/main/resources/notification.json
@@ -7,6 +7,9 @@
       "global_cc": [
         "${pass.notification.demo.global.cc.address}"
       ],
+      "global_bcc": [
+        "${pass.notification.demo.global.bcc.address}"
+      ],
       "whitelist": [
         "staffWithGrants@jhu.edu",
         "staffWithNoGrants@jhu.edu"

--- a/notification-model/pom.xml
+++ b/notification-model/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       <groupId>org.dataconservancy.pass.notify</groupId>
       <artifactId>notify-parent</artifactId>
-      <version>0.0.3-3.4-SNAPSHOT</version>
+      <version>0.1.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>notification-model</artifactId>

--- a/notification-model/src/main/java/org/dataconservancy/pass/notification/model/Notification.java
+++ b/notification-model/src/main/java/org/dataconservancy/pass/notification/model/Notification.java
@@ -132,6 +132,8 @@ public interface Notification {
 
     Collection<String> getCc();
 
+    Collection<String> getBcc();
+
     Type getType();
 
     Map<Param, String> getParameters();

--- a/notification-model/src/main/java/org/dataconservancy/pass/notification/model/SimpleNotification.java
+++ b/notification-model/src/main/java/org/dataconservancy/pass/notification/model/SimpleNotification.java
@@ -71,6 +71,7 @@ public class SimpleNotification implements Notification {
      */
     private URI resourceUri;
 
+    @Override
     public Collection<String> getRecipients() {
         return recipients;
     }
@@ -79,6 +80,7 @@ public class SimpleNotification implements Notification {
         this.recipients = recipients;
     }
 
+    @Override
     public Collection<String> getCc() {
         return cc;
     }
@@ -96,6 +98,7 @@ public class SimpleNotification implements Notification {
         this.bcc = bcc;
     }
 
+    @Override
     public Type getType() {
         return type;
     }
@@ -104,6 +107,7 @@ public class SimpleNotification implements Notification {
         this.type = type;
     }
 
+    @Override
     public Map<Param, String> getParameters() {
         return parameters;
     }
@@ -112,6 +116,7 @@ public class SimpleNotification implements Notification {
         this.parameters = parameters;
     }
 
+    @Override
     public URI getEventUri() {
         return eventUri;
     }
@@ -120,6 +125,7 @@ public class SimpleNotification implements Notification {
         this.eventUri = eventUri;
     }
 
+    @Override
     public URI getResourceUri() {
         return resourceUri;
     }
@@ -128,6 +134,7 @@ public class SimpleNotification implements Notification {
         this.resourceUri = resourceUri;
     }
 
+    @Override
     public String getSender() {
         return sender;
     }

--- a/notification-model/src/main/java/org/dataconservancy/pass/notification/model/SimpleNotification.java
+++ b/notification-model/src/main/java/org/dataconservancy/pass/notification/model/SimpleNotification.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Encapsulates {@link Notification} metadata used to dispatch the notification.
@@ -41,6 +42,11 @@ public class SimpleNotification implements Notification {
      * Additional recipients, may be URIs to PASS {@code User}s
      */
     private Collection<String> cc;
+
+    /**
+     * Additional recipients, must be RFC 822 email addresses.  URIs must not be used.
+     */
+    private Collection<String> bcc;
 
     /**
      * The type of {@link Notification}
@@ -79,6 +85,15 @@ public class SimpleNotification implements Notification {
 
     public void setCc(Collection<String> cc) {
         this.cc = cc;
+    }
+
+    @Override
+    public Collection<String> getBcc() {
+        return bcc;
+    }
+
+    public void setBcc(Collection<String> bcc) {
+        this.bcc = bcc;
     }
 
     public Type getType() {
@@ -122,6 +137,20 @@ public class SimpleNotification implements Notification {
     }
 
     @Override
+    public String toString() {
+        return new StringJoiner("\n  ", SimpleNotification.class.getSimpleName() + "[", "]")
+                .add("recipients=" + recipients)
+                .add("sender='" + sender + "'")
+                .add("cc=" + cc)
+                .add("bcc=" + bcc)
+                .add("type=" + type)
+                .add("parameters=" + parameters)
+                .add("eventUri=" + eventUri)
+                .add("resourceUri=" + resourceUri)
+                .toString();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o)
             return true;
@@ -131,6 +160,7 @@ public class SimpleNotification implements Notification {
         return Objects.equals(recipients, that.recipients) &&
                 Objects.equals(sender, that.sender) &&
                 Objects.equals(cc, that.cc) &&
+                Objects.equals(bcc, that.bcc) &&
                 type == that.type &&
                 Objects.equals(parameters, that.parameters) &&
                 Objects.equals(eventUri, that.eventUri) &&
@@ -139,20 +169,6 @@ public class SimpleNotification implements Notification {
 
     @Override
     public int hashCode() {
-        return Objects.hash(recipients, sender, cc, type, parameters, eventUri, resourceUri);
+        return Objects.hash(recipients, sender, cc, bcc, type, parameters, eventUri, resourceUri);
     }
-
-    @Override
-    public String toString() {
-        return "SimpleNotification{" +
-                "recipients=" + recipients +
-                ", sender='" + sender + '\'' +
-                ", cc=" + cc +
-                ", type=" + type +
-                ", parameters=" + parameters +
-                ", eventUri=" + eventUri +
-                ", resourceUri=" + resourceUri +
-                '}';
-    }
-
 }

--- a/notification-model/src/main/java/org/dataconservancy/pass/notification/model/SimpleNotification.java
+++ b/notification-model/src/main/java/org/dataconservancy/pass/notification/model/SimpleNotification.java
@@ -76,7 +76,7 @@ public class SimpleNotification implements Notification {
         return recipients;
     }
 
-    public void setRecipient(Collection<String> recipients) {
+    public void setRecipients(Collection<String> recipients) {
         this.recipients = recipients;
     }
 

--- a/notification-model/src/main/java/org/dataconservancy/pass/notification/model/config/RecipientConfig.java
+++ b/notification-model/src/main/java/org/dataconservancy/pass/notification/model/config/RecipientConfig.java
@@ -18,8 +18,8 @@ package org.dataconservancy.pass.notification.model.config;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Allows recipients of a notification to be configured depending on the Notification Service {@link #mode mode}.
@@ -37,10 +37,16 @@ public class RecipientConfig {
     private Mode mode;
 
     /**
-     * All notifications for {@link #mode} will be sent to this recipient
+     * All notifications for {@link #mode} will be sent to these recipients
      */
     @JsonProperty("global_cc")
     private Collection<String> globalCc;
+
+    /**
+     * All notifications for {@link #mode} will be blind carbon copied to these recipients
+     */
+    @JsonProperty("global_bcc")
+    private Collection<String> globalBcc;
 
     /**
      * Whitelisted recipients for {@link #mode} will receive notifications directly.  If the recipient on the
@@ -81,7 +87,8 @@ public class RecipientConfig {
     }
 
     /**
-     * All notifications for {@link #mode} will be sent to these recipients
+     * All notifications for {@link #mode} will be sent to these recipients.  Differs from {@link #getGlobalBcc()} as
+     * this method does not blind carbon-copy recipients.
      *
      * @return global recipients for dispatched notifications
      */
@@ -91,6 +98,20 @@ public class RecipientConfig {
 
     public void setGlobalCc(Collection<String> globalCc) {
         this.globalCc = globalCc;
+    }
+
+    /**
+     * All notifications for {@link #mode} will be blind carbon copied to these recipients.  Differs from
+     * {@link #getGlobalCc()} as this method blind carbon-copies recipients.
+     *
+     * @return global, blind, recipients for dispatched notifications
+     */
+    public Collection<String> getGlobalBcc() {
+        return globalBcc;
+    }
+
+    public void setGlobalBcc(Collection<String> globalBcc) {
+        this.globalBcc = globalBcc;
     }
 
     /**
@@ -134,6 +155,17 @@ public class RecipientConfig {
     }
 
     @Override
+    public String toString() {
+        return new StringJoiner("\n  ", RecipientConfig.class.getSimpleName() + "[", "]")
+                .add("mode=" + mode)
+                .add("globalCc=" + globalCc)
+                .add("globalBcc=" + globalBcc)
+                .add("whitelist=" + whitelist)
+                .add("fromAddress='" + fromAddress + "'")
+                .toString();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o)
             return true;
@@ -142,22 +174,13 @@ public class RecipientConfig {
         RecipientConfig that = (RecipientConfig) o;
         return mode == that.mode &&
                 Objects.equals(globalCc, that.globalCc) &&
+                Objects.equals(globalBcc, that.globalBcc) &&
                 Objects.equals(whitelist, that.whitelist) &&
                 Objects.equals(fromAddress, that.fromAddress);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mode, globalCc, whitelist, fromAddress);
-    }
-
-    @Override
-    public String toString() {
-        return "RecipientConfig{" +
-                "mode=" + mode +
-                ", globalCc=" + globalCc +
-                ", whitelist=" + whitelist +
-                ", fromAddress='" + fromAddress + '\'' +
-                '}';
+        return Objects.hash(mode, globalCc, globalBcc, whitelist, fromAddress);
     }
 }

--- a/notification-model/src/test/java/org/dataconservancy/pass/notification/model/config/RecipientConfigTest.java
+++ b/notification-model/src/test/java/org/dataconservancy/pass/notification/model/config/RecipientConfigTest.java
@@ -34,6 +34,10 @@ public class RecipientConfigTest extends AbstractJacksonMappingTest {
             "        \"global_cc\": [\n" +
             "          \"demo@pass.jhu.edu\"\n" +
             "        ],\n" +
+            "        \"global_bcc\": [\n" +
+            "          \"bccdemo1@pass.jhu.edu\",\n" +
+            "          \"bccdemo2@pass.jhu.edu\"\n" +
+            "        ],\n" +
             "        \"whitelist\": [\n" +
             "          \"emetsger@jhu.edu\",\n" +
             "          \"hvu@jhu.edu\",\n" +
@@ -66,9 +70,12 @@ public class RecipientConfigTest extends AbstractJacksonMappingTest {
 //        mapper.writer(SerializationFeature.INDENT_OUTPUT).writeValue(System.err, config);
         assertEquals(Mode.DEMO, config.getMode());
         assertEquals(1, config.getGlobalCc().size());
+        assertEquals(2, config.getGlobalBcc().size());
         assertEquals(4, config.getWhitelist().size());
         assertTrue(config.getGlobalCc().contains("demo@pass.jhu.edu"));
         assertTrue(config.getWhitelist().contains("apb@jhu.edu"));
+        assertTrue(config.getGlobalBcc().contains("bccdemo1@pass.jhu.edu"));
+        assertTrue(config.getGlobalBcc().contains("bccdemo2@pass.jhu.edu"));
         assertRoundTrip(config, RecipientConfig.class);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dataconservancy.pass.notify</groupId>
     <artifactId>notify-parent</artifactId>
-    <version>0.0.3-3.4-SNAPSHOT</version>
+    <version>0.1.0-3.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Notification Services</name>
     <description>Compose and dispatch notifications to users based on PASS events</description>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <docker.indexer.version>oapass/indexer:0.0.18-3.4</docker.indexer.version>
         <docker.elasticsearch.version>docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3</docker.elasticsearch.version>
         <docker.tvial.docker-mailserver.version>oapass/docker-mailserver:20181105</docker.tvial.docker-mailserver.version>
-        <docker.ldap.version>oapass/ldap:20181029</docker.ldap.version>
+        <docker.ldap.version>oapass/ldap:20200610-jhu</docker.ldap.version>
 
         <pass.jsonld.context>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.4.jsonld</pass.jsonld.context>
 


### PR DESCRIPTION
Updates Notification Services to support blind carbon copy emails for notifications.
* binary incompatible with 0.0.2-3.4.  bumps version to 0.1.0-3.4

Configured in the recipient config, just as normal carbon copies are.  Here's an example recipient configuration using the `DEMO` mode (but the configuration is the same for any mode):
```json
"recipient-config": [
    {
      "mode": "DEMO",
      "fromAddress": "${pass.notification.demo.from.address}",
      "global_cc": [
        "${pass.notification.demo.global.cc.address}"
      ],
      "global_bcc": [
        "${pass.notification.demo.global.bcc.address}"
      ],
      "whitelist": [
        "staffWithGrants@jhu.edu",
        "staffWithNoGrants@jhu.edu"
      ]
    },
```