### PR TITLE
Make app constructor protected for tests

### DIFF
--- a/notification-boot/src/main/java/org/dataconservancy/pass/notification/NotificationApp.java
+++ b/notification-boot/src/main/java/org/dataconservancy/pass/notification/NotificationApp.java
@@ -49,6 +49,9 @@ import org.springframework.core.env.Environment;
 @SuppressWarnings({"PMD", "checkstyle:hideutilityclassconstructor"})
 public class NotificationApp {
 
+    protected NotificationApp() {
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(NotificationApp.class);
 
     private static final String GIT_BUILD_VERSION_KEY = "git.build.version";


### PR DESCRIPTION
Not captured in the ITs ticket (https://github.com/eclipse-pass/main/issues/248), but now necessary to get ITs in this repo to work