### PR TITLE
241 java 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - name: "Checkout the repository"
         uses: actions/checkout@v2
-      - name: "Set up JDK 8"
+      - name: "Set up JDK 11"
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: "Cache Maven packages"
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: pass-notification-services Continuous Integration
 on: [ pull_request, workflow_dispatch ]
 
+env:
+  CI: true
+
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .classpath
 .settings/
 target/
+.vscode/
 
 nihms-native-assembler/MetadataSerializerTest.xml
 release.properties

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
             <id>travis</id>
             <activation>
                 <property>
-                    <name>env.TRAVIS</name>
+                    <name>env.CI</name>
                 </property>
             </activation>
             <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <commons-compress.version>1.15</commons-compress.version>
         <commons-io.version>2.6</commons-io.version>
         <commons-text.version>1.4</commons-text.version>
-        <mockito.version>2.12.0</mockito.version>
+        <mockito.version>2.23.4</mockito.version>
         <okhttp.version>3.10.0</okhttp.version>
         <guava.version>23.5-jre</guava.version>
         <args4j.version>2.33</args4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <commons-compress.version>1.15</commons-compress.version>
         <commons-io.version>2.6</commons-io.version>
         <commons-text.version>1.4</commons-text.version>
-        <mockito.version>2.23.4</mockito.version>
+        <mockito.version>2.20.1</mockito.version>
         <okhttp.version>3.10.0</okhttp.version>
         <guava.version>23.5-jre</guava.version>
         <args4j.version>2.33</args4j.version>


### PR DESCRIPTION
Related: https://github.com/eclipse-pass/main/issues/241

* Update dependencies to support Java 11
  * `mockito-core:2.20.1` is the first version with explicit Java 11 support. `v2.23.4` was tried (included transitive dependency updates for better Java 11 support), but resulted in SSL errors in ITs for some reason